### PR TITLE
v0.1.14: added `post.reroot()`; fixed `dx._voxelize_union()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skeliner"
-version = "0.1.13"
+version = "0.1.14"
 description = "A lightweight neuromorphological mesh skeletonizer."
 authors = []
 requires-python = ">=3.10.0"

--- a/skeliner/post.py
+++ b/skeliner/post.py
@@ -347,6 +347,8 @@ def reroot(
     axis: str = "z",
     mode: str = "min",
     prefer_leaves: bool = True,
+    radius_key: str = "median",
+    set_soma_ntype: bool = True,
     rebuild_mst: bool = False,
     verbose: bool = True,
 ):
@@ -414,13 +416,22 @@ def reroot(
     if rebuild_mst:
         edges = _build_mst(nodes, edges)
 
+    if radius_key not in radii:
+        raise KeyError(
+            f"radius_key '{radius_key}' not found in skel.radii "
+            f"(available keys: {tuple(radii)})"
+        )
+    r0 = float(radii[radius_key][0])
     new_soma = Soma.from_sphere(
         center=nodes[0],
-        radius=float(radii["median"][0]),
+        radius=r0,
         verts=node2verts[0]
         if node2verts is not None and node2verts[0].size > 0
         else None,
     )
+
+    if set_soma_ntype and ntype is not None:
+        ntype[0] = 1
 
     new_skel = Skeleton(
         soma=new_soma,

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -4,6 +4,7 @@ Smoke-tests for the mutating helpers in `skeliner.post`.
 Every mutation is done on a *deep copy* of the reference skeleton so the
 other tests stay unaffected.
 """
+
 import copy
 from pathlib import Path
 
@@ -11,6 +12,7 @@ import numpy as np
 import pytest
 
 from skeliner import dx, post, skeletonize
+from skeliner.core import Skeleton, Soma
 from skeliner.io import load_mesh
 
 
@@ -65,7 +67,7 @@ def test_set_ntype_on_subtree(template_skel):
     base = 1 if len(skel.nodes) > 1 else 0
 
     original_code = int(skel.ntype[base])
-    assert original_code != 4             # sanity: it really changes
+    assert original_code != 4  # sanity: it really changes
 
     post.set_ntype(skel, root=base, code=4, subtree=False)
 
@@ -73,3 +75,53 @@ def test_set_ntype_on_subtree(template_skel):
     assert skel.ntype[0] == 1
     changed = np.where(skel.ntype == 4)[0]
     assert set(changed) == {base}
+
+
+def test_reroot_updates_soma_and_ntype():
+    nodes = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], float)
+    edges = np.array([[0, 1], [1, 2]], np.int64)
+    radii = {"median": np.array([2.0, 1.0, 0.8])}
+    ntype = np.array([1, 3, 3], np.int8)
+    s0 = Skeleton(
+        soma=Soma.from_sphere(nodes[0], 2.0, verts=None),
+        nodes=nodes,
+        radii=radii,
+        edges=edges,
+        ntype=ntype,
+    )
+    s = post.reroot(
+        s0, node_id=2, radius_key="median", set_soma_ntype=True, verbose=False
+    )
+    # New soma at new node 0 (old node 2)
+    assert np.allclose(s.soma.center, s.nodes[0])
+    assert np.isclose(s.soma.axes[0], s.soma.axes[1]) and np.isclose(
+        s.soma.axes[1], s.soma.axes[2]
+    )  # spherical
+    assert np.isclose(
+        s.soma.axes[0], s.radii["median"][0]
+    )  # radius equals selected column
+    assert s.ntype[0] == 1
+
+
+def test_reroot_node2verts_vert2node_consistency():
+    nodes = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], float)
+    edges = np.array([[0, 1], [1, 2]], np.int64)
+    radii = {"median": np.array([2.0, 1.0, 0.8])}
+    node2verts = [np.array([10, 11]), np.array([20]), np.array([30, 31])]
+    vert2node = {10: 0, 11: 0, 20: 1, 30: 2, 31: 2}
+    s0 = Skeleton(
+        soma=Soma.from_sphere(nodes[0], 2.0, verts=node2verts[0]),
+        nodes=nodes,
+        radii=radii,
+        edges=edges,
+        ntype=np.array([1, 3, 3], np.int8),
+        node2verts=node2verts,
+        vert2node=vert2node,
+    )
+    s = post.reroot(s0, node_id=2, verbose=False)
+    # Vertex memberships and back-map follow the swap
+    for i, vs in enumerate(s.node2verts):
+        for v in vs:
+            assert s.vert2node[v] == i
+    # Soma verts now come from the new node 0's membership
+    assert set(s.soma.verts.tolist()) == set(s.node2verts[0].tolist())


### PR DESCRIPTION
fix: dx._voxelize_union() failed to exclude soma in the last release when `include_soma=False`. 

It's an embarrassing update so short after the last, so I took this opportunity to add `post.reroot`, which is mostly for skeletons without a true soma (soma detection failed in `skeletonize`), in those cases the default pseudo-soma will not be ideal most of the time, so you might want to reroot the skeleton to another extreme node or a node ID of you choice:

```
skel_rerooted = skel.reroot(axis="z", mode="max")
```

or 

```
skel_rerooted = skel.reroot(node_id=<node_id_of_your_choice>)
```

