### PR TITLE
distance from points to skeleton surface or centerline

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
         steps:
             - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skeliner"
-version = "0.2.1"
+version = "0.2.2"
 description = "A lightweight neuromorphological mesh skeletonizer."
 authors = []
 requires-python = ">=3.10.0"

--- a/skeliner/__init__.py
+++ b/skeliner/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from . import dx, io, pair, plot, post
+from . import batch, dx, io, pair, plot, post
 from .core import Skeleton, skeletonize
 from .plot.vis2d import projection as plot2d
 from .plot.vis2d import threeviews as plot3v
@@ -19,6 +19,7 @@ __all__ = [
     "view3d",
     "io",
     "dx",
+    "batch",
     "post",
     "pair",
     "plot",

--- a/skeliner/batch.py
+++ b/skeliner/batch.py
@@ -1,0 +1,177 @@
+"""skeliner.batch – helpers for querying *multiple* skeletons at once."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Sequence, Tuple
+
+import numpy as np
+
+from . import dx
+if TYPE_CHECKING:
+    from .core import Skeleton
+
+__all__ = ["distance_matrix", "nearest_skeletons"]
+
+
+def _ensure_points(points: Sequence[float] | np.ndarray) -> Tuple[np.ndarray, bool]:
+    """Normalise point input to a (M, 3) float64 array."""
+    pts = np.asarray(points, dtype=np.float64)
+    if pts.ndim == 1:
+        if pts.shape[0] != 3:
+            raise ValueError("points must be a 3-vector or an array of shape (M, 3)")
+        pts = pts[None, :]
+        return pts, True
+    if pts.ndim == 2 and pts.shape[1] == 3:
+        return pts, False
+    raise ValueError("points must be a 3-vector or an array of shape (M, 3)")
+
+
+def _ensure_skeletons(skeletons: Iterable["Skeleton"]) -> Tuple[Tuple["Skeleton", ...], int]:
+    """Freeze iterable of skeletons and validate that each has nodes."""
+    skels = tuple(skeletons)
+    if not skels:
+        raise ValueError("At least one skeleton is required")
+    for idx, skel in enumerate(skels):
+        if skel.nodes.size == 0:
+            raise ValueError(f"Skeleton at index {idx} has no nodes")
+    return skels, len(skels)
+
+
+def distance_matrix(
+    skeletons: Iterable["Skeleton"],
+    points: Sequence[float] | np.ndarray,
+    *,
+    point_unit: str | None = None,
+    k_nearest: int = 4,
+    radius_metric: str | None = None,
+    mode: str = "surface",
+) -> np.ndarray:
+    """
+    Distance from one or more points to *each* skeleton in ``skeletons``.
+
+    Parameters
+    ----------
+    skeletons
+        Iterable of :class:`skeliner.Skeleton` objects to query.
+    points
+        Query location(s) as a single 3-vector or an array of shape (M, 3).
+    point_unit
+        Unit of the input coordinates and returned distances. When ``None``
+        the underlying :func:`skeliner.dx.distance` helper performs no unit
+        conversion.
+    k_nearest
+        Passed through to :func:`skeliner.dx.distance`.
+    radius_metric
+        Radius column name forwarded to :func:`skeliner.dx.distance`.
+    mode
+        Either ``"surface"`` (default) or ``"centerline"`` – same semantics
+        as :func:`skeliner.dx.distance`.
+
+    Returns
+    -------
+    ndarray
+        Array of shape ``(M, S)`` with distances in ``point_unit`` where
+        ``S`` is the number of skeletons and ``M`` the number of query points.
+        A single input point returns an array of shape ``(S,)``.
+    """
+    pts, single = _ensure_points(points)
+    skels, n_skels = _ensure_skeletons(skeletons)
+
+    distances = np.empty((pts.shape[0], n_skels), dtype=np.float64)
+
+    for j, skel in enumerate(skels):
+        d = dx.distance(
+            skel,
+            pts,
+            point_unit=point_unit,
+            k_nearest=k_nearest,
+            radius_metric=radius_metric,
+            mode=mode,
+        )
+        distances[:, j] = d  # d is (M,)
+
+    return distances[0] if single else distances
+
+
+def nearest_skeletons(
+    skeletons: Iterable["Skeleton"],
+    points: Sequence[float] | np.ndarray,
+    *,
+    k: int = 1,
+    point_unit: str | None = None,
+    k_nearest: int = 4,
+    radius_metric: str | None = None,
+    mode: str = "surface",
+    return_all: bool = False,
+) -> Tuple[np.ndarray, np.ndarray] | Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Query the *k* closest skeletons for each point.
+
+    Parameters
+    ----------
+    skeletons
+        Iterable of :class:`skeliner.Skeleton` objects.
+    points
+        Single 3-vector or array of shape (M, 3).
+    k
+        Number of closest skeletons to return per point. Clamped to the
+        number of available skeletons.
+    point_unit, k_nearest, radius_metric, mode
+        Forwarded to :func:`distance_matrix`.
+    return_all
+        When *True* also return the full distance matrix.
+
+    Returns
+    -------
+    distances, indices [, all_distances]
+        Distances and skeleton indices of shape ``(k,)`` for a single point
+        or ``(M, k)`` for multiple points. ``indices`` refer to the order of
+        ``skeletons``. When ``return_all`` is *True* the full distance matrix
+        (``(S,)`` or ``(M, S)``) is appended to the return tuple.
+    """
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    skels, n_skels = _ensure_skeletons(skeletons)
+
+    dist = distance_matrix(
+        skels,
+        points,
+        point_unit=point_unit,
+        k_nearest=k_nearest,
+        radius_metric=radius_metric,
+        mode=mode,
+    )
+
+    k = min(k, n_skels)
+
+    single = dist.ndim == 1
+    if single:
+        # 1D case: distances per skeleton
+        if k == n_skels:
+            idx = np.arange(n_skels, dtype=np.int64)
+            dists = np.asarray(dist, dtype=np.float64)
+        else:
+            part = np.argpartition(dist, k - 1)[:k]
+            dists = dist[part]
+            order = np.argsort(dists)
+            idx = part[order]
+            dists = dists[order]
+
+        return (dists, idx) + ((dist,) if return_all else ())
+
+    # M>1 points – work row-wise
+    if k == n_skels:
+        order = np.argsort(dist, axis=1)
+        idx = np.tile(np.arange(n_skels, dtype=np.int64), (dist.shape[0], 1))
+        idx = np.take_along_axis(idx, order, axis=1)
+        dists = np.take_along_axis(dist, order, axis=1)
+    else:
+        part_idx = np.argpartition(dist, k - 1, axis=1)[:, :k]
+        part_dist = np.take_along_axis(dist, part_idx, axis=1)
+        order = np.argsort(part_dist, axis=1)
+        idx = np.take_along_axis(part_idx, order, axis=1)
+        dists = np.take_along_axis(part_dist, order, axis=1)
+        return (dists, idx) + ((dist,) if return_all else ())
+
+    return (dists, idx) + ((dist,) if return_all else ())

--- a/skeliner/batch.py
+++ b/skeliner/batch.py
@@ -149,7 +149,7 @@ def nearest_skeletons(
     radius_metric: str | None = None,
     mode: str = "surface",
     return_all: bool = False,
-    structured: bool = False,
+    structured: bool = True,
     id_field: str = "id",
 ) -> (
     Tuple[np.ndarray, np.ndarray]
@@ -173,8 +173,9 @@ def nearest_skeletons(
     return_all
         When *True* also return the full distance matrix.
     structured
-        When *True* return a human-friendly summary that lists the nearest
+        When *True* (default) return a human-friendly summary that lists the nearest
         skeletons per point together with their meta IDs instead of the raw arrays.
+        Pass ``False`` to preserve the legacy tuple return style.
     id_field
         Key looked up on :attr:`Skeleton.meta` when building the structured
         summary. Only consulted when ``structured`` is *True*.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+# Ensure Matplotlib (pulled indirectly by trimesh during tests) has a writable
+# cache directory even inside read-only home environments.
+_mpl_cache = Path(tempfile.gettempdir()) / "skeliner-mpl-cache"
+_mpl_cache.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", str(_mpl_cache))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -7,12 +7,15 @@ from skeliner import batch, dx
 from skeliner.core import Skeleton, Soma
 
 
-def make_line_skeleton(base: np.ndarray) -> Skeleton:
+def make_line_skeleton(base: np.ndarray, *, skel_id: str | None = None) -> Skeleton:
     base = np.asarray(base, dtype=np.float64)
     nodes = np.vstack([base, base + np.array([10.0, 0.0, 0.0])])
     radii = np.array([1.0, 1.0], dtype=np.float64)
     edges = np.array([[0, 1]], dtype=np.int64)
     soma = Soma.from_sphere(center=base, radius=1.0, verts=None)
+    meta = {"unit": "nm"}
+    if skel_id is not None:
+        meta["id"] = skel_id
     return Skeleton(
         soma=soma,
         nodes=nodes,
@@ -21,7 +24,7 @@ def make_line_skeleton(base: np.ndarray) -> Skeleton:
         ntype=None,
         node2verts=None,
         vert2node=None,
-        meta={"unit": "nm"},
+        meta=meta,
         extra={},
     )
 
@@ -29,9 +32,9 @@ def make_line_skeleton(base: np.ndarray) -> Skeleton:
 @pytest.fixture()
 def simple_skeletons() -> list[Skeleton]:
     return [
-        make_line_skeleton(np.array([0.0, 0.0, 0.0])),
-        make_line_skeleton(np.array([100.0, 0.0, 0.0])),
-        make_line_skeleton(np.array([-80.0, 0.0, 0.0])),
+        make_line_skeleton(np.array([0.0, 0.0, 0.0]), skel_id="proximal"),
+        make_line_skeleton(np.array([100.0, 0.0, 0.0]), skel_id="distal"),
+        make_line_skeleton(np.array([-80.0, 0.0, 0.0]), skel_id="left"),
     ]
 
 
@@ -60,11 +63,14 @@ def test_nearest_single_point(simple_skeletons):
         simple_skeletons,
         np.array([102.5, 0.0, 0.0]),
         point_unit="nm",
+        structured=False,
     )
     assert distance.shape == (1,)
     assert index.shape == (1,)
     assert index[0] == 1  # middle skeleton
-    expected = dx.distance(simple_skeletons[1], np.array([102.5, 0.0, 0.0]), point_unit="nm")
+    expected = dx.distance(
+        simple_skeletons[1], np.array([102.5, 0.0, 0.0]), point_unit="nm"
+    )
     assert distance[0] == pytest.approx(expected)
 
 
@@ -82,6 +88,7 @@ def test_nearest_multiple_points(simple_skeletons):
         points,
         k=2,
         point_unit="nm",
+        structured=False,
     )
     assert distances.shape == (3, 2)
     assert indices.shape == (3, 2)
@@ -94,6 +101,63 @@ def test_nearest_multiple_points(simple_skeletons):
     assert np.allclose(distances, expected_dist)
 
 
+def test_structured_single_point(simple_skeletons):
+    summary = batch.nearest_skeletons(
+        simple_skeletons,
+        np.array([102.5, 0.0, 0.0]),
+        point_unit="nm",
+        k=2,
+        structured=True,
+    )
+    assert isinstance(summary, dict)
+    assert summary["point_index"] == 0
+    assert summary["matches"][0]["skeleton_id"] == "distal"
+    assert summary["matches"][1]["skeleton_id"] == "proximal"
+    assert summary["matches"][0]["skeleton_index"] == 1
+    assert summary["matches"][0]["distance"] < summary["matches"][1]["distance"]
+
+
+def test_structured_multiple_points(simple_skeletons):
+    points = np.array(
+        [
+            [2.0, 0.0, 0.0],
+            [120.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    summary = batch.nearest_skeletons(
+        simple_skeletons,
+        points,
+        k=1,
+        point_unit="nm",
+        structured=True,
+    )
+    assert isinstance(summary, list)
+    assert summary[0]["matches"][0]["skeleton_id"] == "proximal"
+    assert summary[1]["matches"][0]["skeleton_id"] == "distal"
+    assert "all_distances" not in summary[0]
+    assert summary[0]["matches"][0]["skeleton_index"] == 0
+    assert summary[1]["matches"][0]["skeleton_index"] == 1
+
+
+def test_structured_with_full_distances(simple_skeletons):
+    points = np.array([[10.0, 0.0, 0.0], [110.0, 0.0, 0.0]])
+    summary = batch.nearest_skeletons(
+        simple_skeletons,
+        points,
+        structured=True,
+        return_all=True,
+        point_unit="nm",
+    )
+    assert isinstance(summary, list)
+    assert np.allclose(
+        np.asarray(summary[0]["all_distances"]),
+        batch.distance_matrix(simple_skeletons, points[0], point_unit="nm"),
+    )
+    assert len(summary[0]["all_distances"]) == len(simple_skeletons)
+    assert len(summary[1]["all_distances"]) == len(simple_skeletons)
+
+
 def test_nearest_k_clamped(simple_skeletons):
     points = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
     distances, indices = batch.nearest_skeletons(
@@ -101,6 +165,7 @@ def test_nearest_k_clamped(simple_skeletons):
         points,
         k=10,
         point_unit="nm",
+        structured=False,
     )
     assert distances.shape == (1, 3)
     assert indices.shape == (1, 3)
@@ -119,13 +184,12 @@ def test_return_all_matrix(simple_skeletons):
         points,
         k=1,
         return_all=True,
+        structured=False,
         point_unit="nm",
     )
     assert matrix.shape == (2, 3)
     assert np.allclose(distances[:, 0], np.min(matrix, axis=1))
-    assert np.array_equal(
-        indices[:, 0], np.argmin(matrix, axis=1)
-    )
+    assert np.array_equal(indices[:, 0], np.argmin(matrix, axis=1))
 
 
 def test_invalid_inputs(simple_skeletons):


### PR DESCRIPTION
## Distance from multiple points to one skeleton

To measure the distance between some points to a skeleton, you can use `dx.distance(skel, points)`, or directly from a Skeleton object:

```python
import skeliner as sk

skel = sk.io.load_npz("../temp_io/720575940550605504.npz")
skel.distance(skel.nodes, mode="centerline")
```

will returns 0 for all nodes, as the nodes are the centerline.

if we change it a bit:

```python
skel.distance(skel.nodes[100]+ 163, mode="surface"), skel.distance(skel.nodes[100] + 141, mode="centerline")
```

will return

```
(7.226243952925699, 148.54367737047386)
```

## Batch distance

a new `batch.py` module can also find the top k nearest skeletons for multiple points

```python
import skeliner as sk

# load some cells
dsgc = sk.io.load_npz("../../../data/DSGC/720575940567182923/skeleton.npz")
sac_offs = [sk.io.load_npz(f"../../../data/SAC-OFF/{cid}/skeleton.npz") for cid in [720575940547803011, 720575940554656742, 720575940572154471]]

# picks some points for testing
points = []
for i in range(3):
    contact_seeds = sk.pair.find_contact_seeds(dsgc, sac_offs[i])
    points.append(contact_seeds.pos[2])

sk.batch.nearest_skeletons(skeletons=[dsgc] + sac_offs, points=points, k=2)
```

this will return

```
[{'point_index': 0,
  'point': [499.73781427336235, 471.3932988369569, 43.056525600559425],
  'matches': [{'skeleton_index': 0,
    'skeleton_id': 720575940567182923,
    'distance': 0.0},
   {'skeleton_index': 1, 'skeleton_id': 720575940547803011, 'distance': 0.0}]},
 {'point_index': 1,
  'point': [420.4119215774796, 399.5634949644302, 55.745175985484856],
  'matches': [{'skeleton_index': 0,
    'skeleton_id': 720575940567182923,
    'distance': 0.0},
   {'skeleton_index': 2, 'skeleton_id': 720575940554656742, 'distance': 0.0}]},
 {'point_index': 2,
  'point': [403.9949115638043, 385.27809952845183, 57.7712639337827],
  'matches': [{'skeleton_index': 0,
    'skeleton_id': 720575940567182923,
    'distance': 0.0},
   {'skeleton_index': 3, 'skeleton_id': 720575940572154471, 'distance': 0.0}]}]
```

as expected, the test points are the contact seeds between the DSGC and three different OFF SAC, so the DSGC will always be the closest cell to all three points, and each SAC will be closest to one of the point. 