### PR TITLE
Change: more sensible default and handling of `ntype`

### DIFF
--- a/skeliner/dataclass.py
+++ b/skeliner/dataclass.py
@@ -292,16 +292,16 @@ class Skeleton:
 
         # ---- ntype ---------------------------------------------------
         if self.ntype is None:
-            # create default label vector: soma=1, rest=dendrite (3)
-            ntype = np.full(N, 3, dtype=np.int8)
+            # create default label vector: root=-1, rest=unknown (0)
+            ntype = np.full(N, 0, dtype=np.int8)
             if N:
-                ntype[0] = 1
+                ntype[0] = -1
                 self.ntype = ntype
         else:
             self.ntype = np.asanyarray(self.ntype, dtype=np.int8).reshape(-1)
             if len(self.ntype) != N:
                 raise ValueError("ntype length must match number of nodes")
-            self.ntype[0] = 1  # always enforce soma label
+            self.ntype[0] = -1 if not (self.ntype[0] in [-1, 1]) else self.ntype[0]  # root must be "root" or "soma"
 
         if self.soma is not None:
             if self.soma.verts is not None and self.soma.verts.ndim != 1:

--- a/skeliner/io.py
+++ b/skeliner/io.py
@@ -178,7 +178,7 @@ def to_swc(
 ) -> None:
     """Write the skeleton to SWC.
 
-    The first node (index 0) is written as type 1 (soma) and acts as the
+    The first node (index 0) is written as type -1 if ntype is None and acts as the
     root of the morphology tree. Parent IDs are therefore 1‑based to
     comply with the SWC format.
 
@@ -309,7 +309,9 @@ def load_npz(path: str | Path) -> Skeleton:
         if "neighbors_idx" in z.files and "neighbors_off" in z.files:
             idx = z["neighbors_idx"].astype(np.int64)
             off = z["neighbors_off"].astype(np.int64)
-            node_neighbors = tuple(idx[off[i] : off[i + 1]] for i in range(len(off) - 1))
+            node_neighbors = tuple(
+                idx[off[i] : off[i + 1]] for i in range(len(off) - 1)
+            )
 
     skel = Skeleton(
         nodes=nodes,
@@ -327,7 +329,6 @@ def load_npz(path: str | Path) -> Skeleton:
     if node_neighbors is not None:
         skel._node_neighbors = node_neighbors
     return skel
-
 
 
 def to_npz(

--- a/skeliner/io.py
+++ b/skeliner/io.py
@@ -225,9 +225,9 @@ def to_swc(
     if skeleton.ntype is not None:
         ntype = skeleton.ntype.astype(int, copy=False)
     else:
-        ntype = np.full(len(nodes), 3, dtype=int)
+        ntype = np.full(len(nodes), 0, dtype=int)  # default to "unknown"
         if len(ntype):
-            ntype[0] = 1
+            ntype[0] = -1  # default to "root"
 
     # --- write SWC file -----------------------------------------------
     with path.open("w", encoding="utf8") as fh:
@@ -242,7 +242,7 @@ def to_swc(
             zip(nodes[:, axis_order] * scale, radii * scale, parent, ntype), start=1
         ):
             fh.write(
-                f"{idx} {int(t if idx != 1 else 1)} "  # ensure soma has type 1
+                f"{idx} {int(-1 if ((idx == 1) and not (t in [-1, 1])) else t)} "  # ensure soma has type -1 or +1
                 f"{coord[0]} {coord[1]} {coord[2]} {r} "
                 f"{(pa + 1) if pa != -1 else -1}\n"
             )
@@ -270,9 +270,9 @@ def load_npz(path: str | Path) -> Skeleton:
         if "ntype" in z:
             ntype = z["ntype"].astype(np.int8)
         else:
-            ntype = np.full(len(nodes), 3, dtype=np.int8)
+            ntype = np.full(len(nodes), 0, dtype=np.int8)  # default to "unknown"
             if len(ntype):
-                ntype[0] = 1
+                ntype[0] = -1  # default to "root"
 
         # reconstruct ragged node2verts
         idx = z["node2verts_idx"].astype(np.int64)

--- a/skeliner/plot/vis2d.py
+++ b/skeliner/plot/vis2d.py
@@ -211,6 +211,7 @@ def _resample_n(cmap: mcolors.Colormap, n: int) -> mcolors.Colormap:
 
 
 _SWC_ALIASES = {
+    "root": -1,
     "undefined": 0,
     "undef": 0,
     "unknown": 0,
@@ -228,14 +229,14 @@ _SWC_ALIASES = {
 }
 
 # Keep stable aesthetic order (your previous mapping of SWC→index)
-_DEFAULT_IDX_BY_TYPE = {0: 6, 1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5}
+_DEFAULT_IDX_BY_TYPE = {-1: 7, 0: 6, 1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5}
 
 
 def _key_to_swc_typecode(key: int | str) -> int:
     if isinstance(key, int):
-        if 0 <= key <= 6:
+        if -1 <= key <= 6:
             return key
-        raise ValueError("SWC type code must be in 0..6")
+        raise ValueError("SWC type code must be in -1..6")
     k = key.strip().lower()
     if k not in _SWC_ALIASES:
         valid = ", ".join(sorted(set(_SWC_ALIASES)))
@@ -244,15 +245,15 @@ def _key_to_swc_typecode(key: int | str) -> int:
 
 
 def _palette_from_base(base_cmap_like) -> np.ndarray:
-    """Return (7,4) RGBA palette ordered by SWC 0..6 from a base colormap."""
-    base = _resample_n(_as_cmap(base_cmap_like), 7)
+    """Return (7,4) RGBA palette ordered by SWC -1..6 from a base colormap."""
+    base = _resample_n(_as_cmap(base_cmap_like), 8)
     rows = (
         np.asarray(base.colors)
         if hasattr(base, "colors")
-        else base(np.linspace(0, 1, 7))
+        else base(np.linspace(0, 1, 8))
     )
-    swc = np.empty((7, 4), float)
-    for t in range(7):
+    swc = np.empty((8, 4), float)
+    for t in range(8):
         swc[t] = rows[_DEFAULT_IDX_BY_TYPE[t]]
     return swc
 
@@ -260,9 +261,9 @@ def _palette_from_base(base_cmap_like) -> np.ndarray:
 def _resolve_swc_palette_from_skel_cmap(skel_cmap) -> np.ndarray:
     """
     Accepts:
-      - str / Colormap / sequence → derive 7-color palette
+      - str / Colormap / sequence → derive 8-color palette
       - dict {name|code: color, ...} with optional '__base__'
-    Returns (7,4) RGBA array indexed by SWC code 0..6.
+    Returns (8,4) RGBA array indexed by SWC code -1..6.
     """
     overrides: dict[int, str | tuple | list] = {}
     if isinstance(skel_cmap, Mapping):

--- a/skeliner/plot/vis2d.py
+++ b/skeliner/plot/vis2d.py
@@ -253,7 +253,7 @@ def _palette_from_base(base_cmap_like) -> np.ndarray:
         else base(np.linspace(0, 1, 8))
     )
     swc = np.empty((8, 4), float)
-    for t in range(8):
+    for t in range(-1, 7):
         swc[t] = rows[_DEFAULT_IDX_BY_TYPE[t]]
     return swc
 

--- a/skeliner/post.py
+++ b/skeliner/post.py
@@ -834,6 +834,8 @@ def reroot(
             dupes = (ntype == 1) | (ntype == -1)
             dupes[0] = False
             ntype[dupes] = 0  # Default to unknown
+        ntype = _fill_ntype_gaps(ntype, edges)
+        ntype = _ensure_root_label(ntype, ntype[0])
 
     new_skel = Skeleton(
         soma=new_soma,

--- a/skeliner/skeletonize.py
+++ b/skeliner/skeletonize.py
@@ -798,11 +798,14 @@ def skeletonize(
                 f"({soma_ms:.2f} + {core_ms:.2f})"
             )
 
+    ntype = np.zeros(len(nodes_arr), np.int8)
+    ntype[0] = 1 if has_soma else -1
+
     return Skeleton(
         nodes=nodes_arr,
         radii=radii_dict,
         edges=edges_mst,
-        ntype=None,
+        ntype=ntype,
         soma=soma,
         node2verts=node2verts,
         vert2node=vert2node,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ Core pipeline smoke-test.
 Runs `skeletonize()` on the reference mesh and checks a handful of
 topological / numerical invariants so that regressions blow up early.
 """
+
 from pathlib import Path
 
 import numpy as np
@@ -30,7 +31,7 @@ def _assert_skeleton_valid(skel):
     assert skel.edges.shape[0] == skel.nodes.shape[0] - n_components
 
     # ----- soma is node 0 ----------------------------------------------
-    assert skel.ntype[0] == 1, "node 0 not marked as soma"
+    assert skel.ntype[0] == -1, "node 0 not marked as soma"
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -72,7 +72,7 @@ def test_set_ntype_on_subtree(template_skel):
     post.set_ntype(skel, root=base, code=4, subtree=False)
 
     assert skel.ntype[base] == 4
-    assert skel.ntype[0] == 1
+    assert skel.ntype[0] == -1
     changed = np.where(skel.ntype == 4)[0]
     assert set(changed) == {base}
 


### PR DESCRIPTION
- changed default ntype handling to root=-1/unknown=0 while preserving labels through all postprocessing steps. skeleton init, SWC/NPZ I/O, plotting palette, and remapping logic honor -1/0, with soma explicitly 1 when detected
- `ntype` remapping now aggregates labels when nodes merge (majority with a fixed priority), enforces a single root/soma, and fills zero gaps from neighboring labels.
- all node/edge-altering post ops (drop/keep, merge_near_soma_nodes, prune_neurites, detect_soma, downsample, reroot) now re-align `ntype` using the new remap + gap-fill; reroot also fills gaps after clearing duplicate -1/1 labels.
- visualization: SWC colormap extended to include -1 (“root”) with stable ordering.