### PR TITLE
v0.3.1: editing skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skeliner"
-version = "0.3.0"
+version = "0.3.1"
 description = "A lightweight neuromorphological mesh skeletonizer."
 authors = []
 requires-python = ">=3.10.0"

--- a/skeliner/dx.py
+++ b/skeliner/dx.py
@@ -12,6 +12,7 @@ __skeleton__ = [
     "check_acyclicity",
     "acyclicity",
     "check_bins",
+    "check_mesh_pairing",
     "edge_support",
     "face_owner",
     "bin_faces",
@@ -205,6 +206,105 @@ def check_bins(skel, *, mesh=None, return_report: bool = False):
     return report
 
 
+def check_mesh_pairing(skel, mesh, *, return_report: bool = False):
+    """Is *mesh* the surface ``skel`` was built from?
+
+    A skeleton's bins name vertex *ids* and nothing else, so the ids alone
+    cannot say which mesh they belong to.  Paired with a **larger** unrelated
+    mesh every id stays in range, bins resolve to real faces, and every answer
+    downstream — the surface a node owns, which pairs the surface joins, what
+    a repartition would do — is computed against the wrong cell and returned
+    without complaint.  A *smaller* one merely raises ``IndexError``, which is
+    the safer failure of the two.
+
+    Two independent things are asked, and they answer differently:
+
+    ``in range``
+        Every id ``node2verts`` names exists in the mesh.  A **necessary**
+        condition, checkable on any skeleton ever written, and the one that
+        rules out the smaller-mesh crash.
+    ``counts``
+        ``meta["mesh"]`` against the loaded mesh, when the skeleton carries
+        it.  Exact, and it survives the ``.obj`` / ``.ply`` round trip that
+        moves coordinates in the ninth decimal — which is why this is counts
+        and not a hash of the vertex array.
+
+    Skeletons written before ``meta["mesh"]`` existed carry no counts, so
+    ``ok`` is the most that can be said of them and ``verified`` stays
+    *False*.  The two are kept apart deliberately: *nothing contradicts this*
+    is a weaker claim than *this is the right mesh*, and collapsing them would
+    present a legacy skeleton as confirmed.
+
+    Parameters
+    ----------
+    skel
+        A :class:`skeliner.Skeleton` instance.
+    mesh
+        The mesh to test it against.
+    return_report
+        Return a dict of details instead of a boolean.
+
+    Returns
+    -------
+    bool or dict
+        ``ok`` is *False* only when something is positively contradicted.
+        The dict also carries ``verified`` and a human-readable ``reason``.
+    """
+    n_verts = int(len(mesh.vertices))
+    n_faces = int(len(mesh.faces))
+    recorded = (skel.meta or {}).get("mesh") or {}
+
+    def _out(ok, verified, reason, **extra):
+        if not return_report:
+            return bool(ok)
+        return {
+            "ok": bool(ok),
+            "verified": bool(verified),
+            "reason": reason,
+            "meshVertices": n_verts,
+            "meshFaces": n_faces,
+            **extra,
+        }
+
+    n2v = skel.node2verts
+    if n2v is None:
+        return _out(False, False, "skeleton carries no mesh data")
+
+    highest = -1
+    for b in n2v:
+        b = np.asarray(b, dtype=np.int64).ravel()
+        if b.size:
+            highest = max(highest, int(b.max()))
+    if highest >= n_verts:
+        return _out(
+            False,
+            False,
+            f"the skeleton names vertex {highest:,}, but the mesh has only "
+            f"{n_verts:,} vertices — it was not built from this mesh",
+            highestVertex=highest,
+        )
+
+    want_v, want_f = recorded.get("n_vertices"), recorded.get("n_faces")
+    if want_v is None:
+        return _out(
+            True,
+            False,
+            "the skeleton records no mesh counts, so the pairing cannot be "
+            "confirmed — only that nothing contradicts it",
+            highestVertex=highest,
+        )
+    if int(want_v) != n_verts or (want_f is not None and int(want_f) != n_faces):
+        return _out(
+            False,
+            False,
+            f"the skeleton was built from a mesh of {int(want_v):,} vertices / "
+            f"{int(want_f):,} faces; this one has {n_verts:,} / {n_faces:,}",
+            expectedVertices=int(want_v),
+            expectedFaces=int(want_f) if want_f is not None else None,
+        )
+    return _out(True, True, "counts match the mesh this was built from")
+
+
 def edge_support(skel, mesh) -> Dict[str, Any]:
     """Which node pairs the mesh surface joins, against which ones the tree has.
 
@@ -310,6 +410,16 @@ def face_owner(skel, mesh) -> np.ndarray:
     lut = np.full(len(mesh.vertices), -1, dtype=np.int64)
     keys = np.fromiter(skel.vert2node.keys(), np.int64, len(skel.vert2node))
     vals = np.fromiter(skel.vert2node.values(), np.int64, len(skel.vert2node))
+    # An id past the end means this is not the mesh the bins were built over.
+    # Left to numpy it is an IndexError naming an array nobody passed in; a
+    # mesh one vertex *larger* than the original would not raise at all, which
+    # is what :func:`check_mesh_pairing` is for.
+    if keys.size and int(keys.max()) >= len(mesh.vertices):
+        raise ValueError(
+            f"skeleton names vertex {int(keys.max()):,} but the mesh has "
+            f"{len(mesh.vertices):,} vertices — it was not built from this "
+            "mesh (see dx.check_mesh_pairing)"
+        )
     lut[keys] = vals
 
     per_face = np.sort(lut[np.asarray(mesh.faces)], axis=1)

--- a/skeliner/dx.py
+++ b/skeliner/dx.py
@@ -22,6 +22,7 @@ __skeleton__ = [
     "branches_of_length",
     "twigs_of_length",
     "suspicious_tips",
+    "suspicious_junctions",
     "distance",
     "node_summary",
     "extract_neurites",
@@ -1084,6 +1085,260 @@ def suspicious_tips(
 
     suspicious_sorted = sorted(suspicious, key=lambda nid: -stats[int(nid)]["ratio"])
     return suspicious_sorted, stats
+
+
+def _arm_cables(skel, min_degree: int) -> Dict[int, Dict[str, Any]]:
+    """Decompose every junction into the cable each of its arms carries.
+
+    Deleting node *i* splits the tree into one component per neighbour.  The
+    component reached through the parent is *proximal* (it holds the soma);
+    the rest are *distal*.  This is the measurement
+    :func:`suspicious_junctions` thresholds, kept separate because which
+    thresholds are right is an open question and the raw numbers are what
+    answers it.
+
+    Linear in the number of nodes.  The naive form — delete a node, flood
+    each arm, repeat — is O(N²) and visits billions of nodes on a 50k-node
+    skeleton.  Rooting the tree at the soma makes the same decomposition a
+    single post-order accumulation:
+
+    ``sub[v]``
+        cable strictly inside the subtree rooted at *v*.
+    distal arm through child *c*
+        ``sub[c] + len(i, c)``
+    proximal arm
+        ``total − sub[i]``
+
+    which sums back to ``total`` exactly, so the arms partition the cable
+    rather than merely sampling it.
+
+    A disconnected skeleton is handled by rooting **each** component at its
+    lowest node id; for the component holding the soma that is node 0, so the
+    usual case is unchanged and the orphan components still get measured
+    instead of raising.
+
+    Recursion is avoided throughout — a long neurite is a deep tree, and the
+    recursive form overflows the stack on real cells.
+    """
+    n = len(skel.nodes)
+    edges = np.asarray(skel.edges, dtype=np.int64).reshape(-1, 2)
+    if n == 0 or edges.size == 0:
+        return {}
+
+    nodes = np.asarray(skel.nodes, dtype=np.float64)
+    lengths = np.linalg.norm(nodes[edges[:, 0]] - nodes[edges[:, 1]], axis=1)
+
+    # CSR-style adjacency: neighbour ids and the length of the edge used.
+    deg = np.bincount(edges.reshape(-1), minlength=n)
+    start = np.zeros(n + 1, dtype=np.int64)
+    np.cumsum(deg, out=start[1:])
+    fill = start[:-1].copy()
+    adj = np.empty(2 * len(edges), dtype=np.int64)
+    adj_len = np.empty(2 * len(edges), dtype=np.float64)
+    for (a, b), ln in zip(edges, lengths, strict=True):
+        adj[fill[a]] = b
+        adj_len[fill[a]] = ln
+        fill[a] += 1
+        adj[fill[b]] = a
+        adj_len[fill[b]] = ln
+        fill[b] += 1
+
+    parent = np.full(n, -1, dtype=np.int64)
+    parent_len = np.zeros(n, dtype=np.float64)
+    order = np.empty(n, dtype=np.int64)  # BFS order, roots first
+    seen = np.zeros(n, dtype=bool)
+    k = 0
+    for root in range(n):  # node 0 first, so the soma roots its own component
+        if seen[root]:
+            continue
+        seen[root] = True
+        order[k] = root
+        k += 1
+        head = k - 1
+        while head < k:
+            v = order[head]
+            head += 1
+            for j in range(start[v], start[v + 1]):
+                w = adj[j]
+                if not seen[w]:
+                    seen[w] = True
+                    parent[w] = v
+                    parent_len[w] = adj_len[j]
+                    order[k] = w
+                    k += 1
+
+    # Post-order accumulation: walk the BFS order backwards, so every child is
+    # finished before its parent is read.
+    sub = np.zeros(n, dtype=np.float64)
+    for idx in range(n - 1, -1, -1):
+        v = order[idx]
+        p = parent[v]
+        if p >= 0:
+            sub[p] += sub[v] + parent_len[v]
+
+    # Total cable of the component each node belongs to — the proximal arm is
+    # measured against its own component, not the whole file.
+    comp_total = np.zeros(n, dtype=np.float64)
+    comp_of = np.zeros(n, dtype=np.int64)
+    for idx in range(n):
+        v = order[idx]
+        comp_of[v] = v if parent[v] < 0 else comp_of[parent[v]]
+    for v in range(n):
+        comp_total[v] = sub[comp_of[v]]
+
+    out: Dict[int, Dict[str, Any]] = {}
+    for v in range(n):
+        if deg[v] < min_degree or parent[v] < 0:
+            # A component root has no proximal arm, so "one arm holds the
+            # soma and the others do not" is undefined there.  The soma is
+            # legitimately high-degree anyway.
+            continue
+        distal = [
+            float(sub[adj[j]] + adj_len[j])
+            for j in range(start[v], start[v + 1])
+            if adj[j] != parent[v]
+        ]
+        distal.sort(reverse=True)
+        out[int(v)] = {
+            "degree": int(deg[v]),
+            "proximal_cable": float(comp_total[v] - sub[v]),
+            "distal_cables": distal,
+        }
+    return out
+
+
+def suspicious_junctions(
+    skel,
+    *,
+    min_degree: int = 4,
+    min_distal_cable: float = 250.0,
+    cable_unit: str = "um",
+    min_components: int = 2,
+    group_regions: bool = True,
+    return_stats: bool = False,
+):
+    """Junctions where two or more substantial arbors meet — merge candidates.
+
+    A segmentation merge fuses two unrelated neurites in the *mesh*, so the
+    skeleton grows a junction welding two independent arbors together.  The
+    result is still a valid tree — one root, ``E = N − 1``, connected,
+    acyclic — so :func:`check_connectivity` and :func:`check_acyclicity`
+    cannot see it.  What gives it away is the shape: a genuine bifurcation
+    into two long arbors at a single high-degree point is rare, while a merge
+    produces exactly that.
+
+    A node is flagged when its degree is at least *min_degree* **and** at
+    least *min_components* of its distal arms each carry at least
+    *min_distal_cable* of cable.
+
+    This **reports candidates and never clips**.  The rule is a heuristic
+    with no validation behind it, and acting on it destroys real cable, so
+    the cut is a human decision made against the mesh — the same split
+    :mod:`skeliner.pre` draws between its ``find_*`` and ``remove_*``
+    functions.
+
+    Parameters
+    ----------
+    skel
+        A :class:`skeliner.Skeleton` instance.  Assumed acyclic — check with
+        :func:`check_acyclicity` first, since ``post.graft(...,
+        allow_cycle=True)`` can break that assumption.
+    min_degree
+        Minimum graph degree for a node to be considered at all.
+    min_distal_cable
+        How much cable a distal arm must carry to count as substantial,
+        expressed in *cable_unit*.
+    cable_unit
+        Unit *min_distal_cable* is given in, converted into the skeleton's
+        own unit via ``skel.meta["unit"]``.  Skeletons from
+        :func:`~skeliner.skeletonize` are in nanometres by default, so a
+        bare ``250`` in skeleton units would be 250 nm — smaller than a
+        single node radius, which flags every junction.  Naming the unit
+        makes that mistake unrepresentable.
+    min_components
+        How many distal arms must clear *min_distal_cable*.
+    group_regions
+        A merge flags a cluster of adjacent nodes rather than one.  When
+        *True* each connected cluster of flagged nodes collapses to a single
+        representative — the one whose second-largest distal arm is longest
+        — turning an N-item review queue into a handful.
+    return_stats
+        When *True* also return the per-node measurements.  Stats cover
+        **every node examined** (degree ≥ *min_degree*), flagged or not, so
+        a threshold can be re-chosen from them without recomputing.
+
+    Returns
+    -------
+    flagged
+        ``list[int]`` – node ids, most suspicious first (by the second-largest
+        distal arm, which is the arm that made it suspicious).
+    stats
+        *Optional* ``dict[int, dict]`` with ``{"degree", "proximal_cable",
+        "distal_cables"}``; cables are in the skeleton's own unit.
+    """
+    if min_components < 1:
+        raise ValueError("min_components must be at least 1")
+
+    # Resolved before any work: a skeleton that cannot say what its
+    # coordinates mean cannot have a cable threshold applied to it, and
+    # answering "nothing suspicious" for one would be the silent kind of
+    # wrong this whole function exists to avoid.
+    skel_unit = (getattr(skel, "meta", {}) or {}).get("unit")
+    if skel_unit is None:
+        raise ValueError(
+            "skeleton has no meta['unit'], so a cable threshold cannot be "
+            "converted — set one with skel.set_unit(...)"
+        )
+    thresh = min_distal_cable * skel._get_unit_conversion_factor(cable_unit, skel_unit)
+
+    stats = _arm_cables(skel, min_degree)
+    if not stats:
+        return ([], {}) if return_stats else []
+
+    def _rank(nid: int) -> float:
+        """Cable of the arm that made it suspicious."""
+        d = stats[nid]["distal_cables"]
+        return d[min_components - 1] if len(d) >= min_components else -1.0
+
+    flagged = [
+        nid
+        for nid, s in stats.items()
+        if sum(1 for c in s["distal_cables"] if c >= thresh) >= min_components
+    ]
+
+    if group_regions and flagged:
+        flagged = _collapse_adjacent(skel, flagged, key=_rank)
+
+    flagged.sort(key=lambda nid: -_rank(nid))
+    return (flagged, stats) if return_stats else flagged
+
+
+def _collapse_adjacent(skel, nodes: List[int], *, key) -> List[int]:
+    """Reduce each connected cluster of *nodes* to its highest-*key* member."""
+    want = set(int(n) for n in nodes)
+    edges = np.asarray(skel.edges, dtype=np.int64).reshape(-1, 2)
+
+    nbr: Dict[int, List[int]] = {n: [] for n in want}
+    for a, b in edges:
+        a, b = int(a), int(b)
+        if a in want and b in want:
+            nbr[a].append(b)
+            nbr[b].append(a)
+
+    reps: List[int] = []
+    unseen = set(want)
+    while unseen:
+        stack = [unseen.pop()]
+        cluster = [stack[0]]
+        while stack:
+            v = stack.pop()
+            for w in nbr[v]:
+                if w in unseen:
+                    unseen.discard(w)
+                    cluster.append(w)
+                    stack.append(w)
+        reps.append(max(cluster, key=key))
+    return reps
 
 
 def extract_neurites(

--- a/skeliner/dx.py
+++ b/skeliner/dx.py
@@ -11,6 +11,7 @@ __skeleton__ = [
     "connectivity",
     "check_acyclicity",
     "acyclicity",
+    "cycles",
     "check_bins",
     "check_mesh_pairing",
     "edge_support",
@@ -79,16 +80,104 @@ def connectivity(skel, *, return_isolated: bool = False):
 def check_acyclicity(skel, *, return_cycles: bool = False):
     """Check that the skeleton is a *forest* (|E| = |V| − components).
 
-    If a cycle exists and ``return_cycle`` is *True*, a representative list of
-    (u, v) edges forming the cycle is returned.
+    If a cycle exists and ``return_cycles`` is *True*, a representative list
+    of (u, v) edges forming the cycle is returned.
     """
     g = _graph(skel)
     n_comp = len(g.components())
     acyclic = g.ecount() == g.vcount() - n_comp
     if acyclic or not return_cycles:
         return acyclic
-    cyc = g.cycle_basis()[0]  # list of vertex ids
-    return [(cyc[i], cyc[(i + 1) % len(cyc)]) for i in range(len(cyc))]
+    return _cycle_edges(g, g.minimum_cycle_basis()[0])
+
+
+def _cycle_edges(g: ig.Graph, eids) -> List[Tuple[int, int]]:
+    """Edge ids from a cycle basis → ``(u, v)`` pairs, walked in loop order.
+
+    ``minimum_cycle_basis`` and ``fundamental_cycles`` return **edge** ids,
+    where the removed ``cycle_basis`` returned **vertex** ids.  Reading the
+    new output as the old — indexing it as a vertex ring — silently yields a
+    plausible list of pairs that are not the cycle, which is why this
+    conversion is one named function rather than repeated at each call site.
+    """
+    pairs = [tuple(sorted(g.es[int(e)].tuple)) for e in eids]
+    nbr: Dict[int, List[int]] = {}
+    for a, b in pairs:
+        nbr.setdefault(a, []).append(b)
+        nbr.setdefault(b, []).append(a)
+
+    start = min(nbr)
+    ring, prev, cur = [start], None, start
+    while True:
+        nxt = next((w for w in nbr[cur] if w != prev), None)
+        if nxt is None or nxt == start:
+            break
+        ring.append(nxt)
+        prev, cur = cur, nxt
+    return [(ring[i], ring[(i + 1) % len(ring)]) for i in range(len(ring))]
+
+
+def cycles(skel, mesh=None) -> List[Dict[str, Any]]:
+    """Every independent loop, and where the tree most likely closed it wrongly.
+
+    A skeleton off the pipeline has no loops — the MST guarantees a tree — so
+    a loop only exists because somebody *asserted* a connection
+    (:func:`skeliner.post.graft` allows one by default, and restoring a
+    surface-supported pair is the usual way).  That assertion is the useful
+    part: the loop it opens is a statement that **two of these edges cannot
+    both be right**, and one of them is a join the MST made that it should
+    not have.
+
+    Which one is not guessed.  With a *mesh*, :func:`edge_support` says which
+    tree edges have no surface behind them at all (``T∖G``), and such an edge
+    lying **on the loop** is the tree claiming a connection the surface does
+    not support while an alternative path exists.  That is the break point,
+    on evidence rather than on a threshold.
+
+    Without a mesh the loop is still reported, with no break point named —
+    which is the honest answer, not a fallback ranking.
+
+    Returns
+    -------
+    list of dict
+        One entry per independent cycle::
+
+            {"nodes": [...],        # in loop order
+             "edges": [(u, v), ...],
+             "breaks": [(u, v), ...],   # unsupported by the surface
+             "length": float}       # loop cable, skeleton units
+
+        Longest loop first — a two-node loop is a duplicated edge, while a
+        long one spans the structure the tree got wrong.
+    """
+    g = _graph(skel)
+    basis = g.minimum_cycle_basis()
+    if not basis:
+        return []
+
+    unsupported: Set[Tuple[int, int]] = set()
+    if mesh is not None:
+        rep = edge_support(skel, mesh)
+        unsupported = {(int(u), int(v)) for u, v in rep["unsupported"]}
+
+    nodes = np.asarray(skel.nodes, dtype=np.float64)
+    out: List[Dict[str, Any]] = []
+    for eids in basis:
+        edges = _cycle_edges(g, eids)
+        ring = [a for a, _ in edges]
+        length = float(sum(np.linalg.norm(nodes[a] - nodes[b]) for a, b in edges))
+        out.append(
+            {
+                "nodes": ring,
+                "edges": edges,
+                "breaks": [
+                    (a, b) for a, b in edges if (min(a, b), max(a, b)) in unsupported
+                ],
+                "length": length,
+            }
+        )
+    out.sort(key=lambda c: -c["length"])
+    return out
 
 
 def acyclicity(skel, *, return_cycles: bool = False):

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -3083,27 +3083,27 @@ let meshCentroid = [0, 0, 0];
                 orphans: [],
                 cycles: [],
                 degree: [
-                    { id: "minDegree", label: "deg≥", value: 4, size: 2,
+                    { id: "minDegree", label: "deg≥", value: 4, size: 2, unit: "edges",
                       title: "List every node at or above this degree." },
                 ],
                 twigs: [
-                    { id: "maxRatio", label: "≤", value: 3, size: 3,
+                    { id: "maxRatio", label: "≤", value: 3, size: 3, unit: "× host radius",
                       title: "Twig cable as a multiple of the radius of the branch node it hangs off. Small means the twig is shorter than its host is thick." },
-                    { id: "maxNodes", label: "nodes≤", value: 3, size: 2,
+                    { id: "maxNodes", label: "nodes≤", value: 3, size: 2, unit: "nodes",
                       title: "Longest twig, in nodes, to list." },
                 ],
                 tips: [
-                    { id: "nearFactor", label: "near", value: 1.2, size: 3,
+                    { id: "nearFactor", label: "near", value: 1.2, size: 3, unit: "× soma axis",
                       title: "Multiple of the largest soma semi-axis inside which a tip counts as close." },
-                    { id: "pathRatio", label: "path≥", value: 2.0, size: 3,
+                    { id: "pathRatio", label: "path≥", value: 2.0, size: 3, unit: "× straight line",
                       title: "Minimum path-length / straight-line ratio." },
                 ],
                 junctions: [
-                    { id: "minDegree", label: "deg≥", value: 4, size: 2,
+                    { id: "minDegree", label: "deg≥", value: 4, size: 2, unit: "edges",
                       title: "Minimum graph degree to consider at all." },
-                    { id: "minCable", label: "arm≥", value: 5, size: 4,
+                    { id: "minCable", label: "arm≥", value: 5, size: 4, unit: "µm",
                       title: "How much cable a distal arm must carry to count as substantial, in um. Two arms must clear it independently." },
-                    { id: "minComponents", label: "arms", value: 2, size: 2,
+                    { id: "minComponents", label: "arms", value: 2, size: 2, unit: "of them",
                       title: "How many distal arms must clear the bar." },
                 ],
             };
@@ -3128,6 +3128,17 @@ let meshCentroid = [0, 0, 0];
                     inp.style.fontSize = "11px";
                     host.appendChild(lab);
                     host.appendChild(inp);
+                    // The unit belongs beside the box, not in a tooltip you
+                    // have to go looking for.  An unlabelled number field
+                    // holding a physical length is how 250 um becomes 250 nm.
+                    if (p.unit) {
+                        const u = document.createElement("span");
+                        u.style.color = "#888";
+                        u.style.marginLeft = "2px";
+                        u.textContent = p.unit;
+                        u.title = p.title;
+                        host.appendChild(u);
+                    }
                 }
             }
 
@@ -4984,9 +4995,14 @@ let meshCentroid = [0, 0, 0];
 
                 const offset = camera.position.clone().sub(controls.target).normalize();
                 controls.target.copy(center);
+                // Framed well back from the marker, because the marker is
+                // the size of the node it sits on and the question is never
+                // about the node alone — it is whether the arms around it
+                // are real.  Sitting a marker-radius away shows the bead and
+                // nothing to judge it against.
                 camera.position
                     .copy(center)
-                    .addScaledVector(offset, Math.max((mk.radius || 50) * 6, 500));
+                    .addScaledVector(offset, Math.max((mk.radius || 50) * 25, 2000));
                 controls.update();
                 scheduleStateUpdate();
 

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -583,11 +583,18 @@
                 <div style="white-space: nowrap; margin-top: 4px">
                     <span style="color: #888" title="List candidates as markers to look at. Nothing here changes the skeleton.">Find:</span>
                     <select id="dxKindSel" style="font-size: 11px; margin-left: 4px">
-                        <option value="junctions">merge candidates</option>
+                        <!-- Named after the dx function each one runs, and
+                             ordered as dx.__skeleton__ orders them: the one
+                             invariant check first, then plain enumerations,
+                             then the heuristics.  So the list reads from
+                             "this is broken" to "this might repay a look",
+                             and the panel neither renames nor resequences
+                             what the library already settled. -->
+                        <option value="orphans">isolated nodes</option>
+                        <option value="degree">nodes of degree</option>
                         <option value="twigs">short twigs</option>
-                        <option value="degree">high-degree nodes</option>
                         <option value="tips">suspicious tips</option>
-                        <option value="orphans">unreachable nodes</option>
+                        <option value="junctions">suspicious junctions</option>
                     </select>
                     <span id="dxParams" style="margin-left: 6px"></span>
                     <button id="dxRunBtn" style="margin-left: 6px">List</button>
@@ -3070,7 +3077,25 @@ let meshCentroid = [0, 0, 0];
             // than constants because no value here is settled: the corpus can
             // rank candidates but cannot say which are real, so the honest
             // interface is one you can turn and watch.
+            // Keys are in the dropdown's order, which is dx.__skeleton__'s.
             const DX_PARAMS = {
+                orphans: [],
+                degree: [
+                    { id: "minDegree", label: "deg≥", value: 4, size: 2,
+                      title: "List every node at or above this degree." },
+                ],
+                twigs: [
+                    { id: "maxRatio", label: "≤", value: 3, size: 3,
+                      title: "Twig cable as a multiple of the radius of the branch node it hangs off. Small means the twig is shorter than its host is thick." },
+                    { id: "maxNodes", label: "nodes≤", value: 3, size: 2,
+                      title: "Longest twig, in nodes, to list." },
+                ],
+                tips: [
+                    { id: "nearFactor", label: "near", value: 1.2, size: 3,
+                      title: "Multiple of the largest soma semi-axis inside which a tip counts as close." },
+                    { id: "pathRatio", label: "path≥", value: 2.0, size: 3,
+                      title: "Minimum path-length / straight-line ratio." },
+                ],
                 junctions: [
                     { id: "minDegree", label: "deg≥", value: 4, size: 2,
                       title: "Minimum graph degree to consider at all." },
@@ -3079,23 +3104,6 @@ let meshCentroid = [0, 0, 0];
                     { id: "minComponents", label: "arms", value: 2, size: 2,
                       title: "How many distal arms must clear the bar." },
                 ],
-                twigs: [
-                    { id: "maxRatio", label: "≤", value: 3, size: 3,
-                      title: "Twig cable as a multiple of the radius of the branch node it hangs off. Small means the twig is shorter than its host is thick." },
-                    { id: "maxNodes", label: "nodes≤", value: 3, size: 2,
-                      title: "Longest twig, in nodes, to list." },
-                ],
-                degree: [
-                    { id: "minDegree", label: "deg≥", value: 4, size: 2,
-                      title: "List every node at or above this degree." },
-                ],
-                tips: [
-                    { id: "nearFactor", label: "near", value: 1.2, size: 3,
-                      title: "Multiple of the largest soma semi-axis inside which a tip counts as close." },
-                    { id: "pathRatio", label: "path≥", value: 2.0, size: 3,
-                      title: "Minimum path-length / straight-line ratio." },
-                ],
-                orphans: [],
             };
 
             function renderDxParams() {

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -624,6 +624,11 @@
                         Skeletonize
                     </button>
                     <button id="skelParamsBtn" style="margin-left: 4px">Set Params</button>
+                    <span
+                        id="skelTrackBadge"
+                        style="margin-left: 6px; color: #7fb3d5; font-size: 11px"
+                        title="What Skeletonize will read. Preprocessed mesh components are used whenever components exist; that route ignores the soma-detection, bridging and pruning parameters, which are only read when skeletonizing from the raw mesh."
+                    ></span>
                     <span id="skelStaleHint" style="margin-left: 8px; color: #e08a3c"></span>
                     <span
                         style="color: #888; margin-left: 12px"
@@ -1198,6 +1203,7 @@ let meshCentroid = [0, 0, 0];
                 try {
                     const resp = await fetch("/loaded");
                     const data = await resp.json();
+                    setTrack(data.track);
                     const meshEl = document.getElementById("loadedMesh");
                     const skelEl = document.getElementById("loadedSkel");
                     if (data.mesh) {
@@ -3643,45 +3649,95 @@ let meshCentroid = [0, 0, 0];
             }
 
             // ── Skeletonize ───────────────────────────────────────────────────
+            //
+            // `tracks` is which tracks actually consult a parameter.
+            // `skeletonize()` accepts every one of these on either track and
+            // simply does not forward the inapplicable ones, so a setting made
+            // against the wrong track is not refused — it is ignored in
+            // silence.  Only three of these apply to both.
+            const BOTH = ["direct", "preprocessing"];
             const SKEL_DEFAULTS = {
-                second_pass: { value: true, type: "bool", label: "Perpendicular re-bin (2nd pass)" },
-                geodesic_shell_count: { value: 1000, type: "int", label: "Shell count" },
-                min_shell_vertices: { value: 6, type: "int", label: "Min shell vertices" },
-                max_shell_width_factor: { value: 50, type: "int", label: "Max shell width factor" },
-                detect_soma: { value: true, type: "bool", label: "Detect soma" },
+                second_pass: { value: true, type: "bool", label: "Perpendicular re-bin (2nd pass)", tracks: ["preprocessing"] },
+                geodesic_shell_count: { value: 1000, type: "int", label: "Shell count", tracks: BOTH },
+                min_shell_vertices: { value: 6, type: "int", label: "Min shell vertices", tracks: BOTH },
+                max_shell_width_factor: { value: 50, type: "int", label: "Max shell width factor", tracks: BOTH },
+                detect_soma: { value: true, type: "bool", label: "Detect soma", tracks: ["direct"] },
                 soma_radius_percentile_threshold: {
                     value: 99.9,
                     type: "float",
                     label: "Soma radius percentile",
+                    tracks: ["direct"],
                 },
-                soma_radius_distance_factor: { value: 4, type: "float", label: "Soma radius dist factor" },
-                soma_min_nodes: { value: 3, type: "int", label: "Soma min nodes" },
-                bridge_gaps: { value: true, type: "bool", label: "Bridge gaps" },
-                collapse_soma: { value: true, type: "bool", label: "Collapse soma" },
-                collapse_soma_dist_factor: { value: 1.2, type: "float", label: "Collapse soma dist factor" },
+                soma_radius_distance_factor: { value: 4, type: "float", label: "Soma radius dist factor", tracks: ["direct"] },
+                soma_min_nodes: { value: 3, type: "int", label: "Soma min nodes", tracks: ["direct"] },
+                bridge_gaps: { value: true, type: "bool", label: "Bridge gaps", tracks: ["direct"] },
+                collapse_soma: { value: true, type: "bool", label: "Collapse soma", tracks: ["direct"] },
+                collapse_soma_dist_factor: { value: 1.2, type: "float", label: "Collapse soma dist factor", tracks: ["direct"] },
                 collapse_soma_radius_factor: {
                     value: 0.2,
                     type: "float",
                     label: "Collapse soma radius factor",
+                    tracks: ["direct"],
                 },
-                prune_tiny_neurites: { value: true, type: "bool", label: "Prune tiny neurites" },
-                prune_tip_extent_factor: { value: 1.2, type: "float", label: "Prune tip extent factor" },
-                prune_stem_extent_factor: { value: 3.0, type: "float", label: "Prune stem extent factor" },
+                prune_tiny_neurites: { value: true, type: "bool", label: "Prune tiny neurites", tracks: ["direct"] },
+                prune_tip_extent_factor: { value: 1.2, type: "float", label: "Prune tip extent factor", tracks: ["direct"] },
+                prune_stem_extent_factor: { value: 3.0, type: "float", label: "Prune stem extent factor", tracks: ["direct"] },
                 merge_nodes_overlap_fraction: {
                     value: 0.8,
                     type: "float",
                     label: "Merge nodes overlap frac",
+                    tracks: ["direct"],
                 },
-                split_elongated_shells: { value: false, type: "bool", label: "Split elongated shells" },
-                split_aspect_thr: { value: 3.0, type: "float", label: "Split aspect threshold" },
-                postprocess: { value: true, type: "bool", label: "Postprocess" },
+                split_elongated_shells: { value: false, type: "bool", label: "Split elongated shells", tracks: ["direct"] },
+                split_aspect_thr: { value: 3.0, type: "float", label: "Split aspect threshold", tracks: ["direct"] },
+                postprocess: { value: true, type: "bool", label: "Postprocess", tracks: ["direct"] },
             };
+
+            // The wire keeps the short ids; what a user reads names what the
+            // track consumes, since "direct" and "preprocessing" say nothing
+            // about which mesh a run is reading.
+            const TRACK_LABEL = {
+                direct: "skeletonize from raw mesh",
+                preprocessing: "skeletonize from preprocessed mesh components",
+            };
+            const trackLabel = (t) => TRACK_LABEL[t] || t;
+
+            // Which track /skeletonize would take now.  Ships on every
+            // broadcast, so this is only ever as stale as the last message.
+            let currentTrack = "direct";
+            let trackShown = false;
+
+            function applies(def) {
+                return (def.tracks || BOTH).includes(currentTrack);
+            }
+
+            function refreshTrackCue() {
+                const badge = document.getElementById("skelTrackBadge");
+                if (badge) badge.textContent = trackLabel(currentTrack);
+                const dialog = document.getElementById("skel-params-dialog");
+                if (dialog && dialog.style.display !== "none") openSkelParams();
+            }
+
+            function setTrack(track) {
+                // The first call still paints, even when the track equals the
+                // default it was initialised to — otherwise a session that
+                // never leaves the direct track shows no badge at all.
+                if (!track || (track === currentTrack && trackShown)) return;
+                currentTrack = track;
+                trackShown = true;
+                refreshTrackCue();
+            }
             let skelParams = {};
             try { const s = JSON.parse(localStorage.getItem('skeliner_skelParams')); if (s) skelParams = s; } catch (e) {}
 
             function getSkelParams() {
                 const params = {};
                 for (const [key, def] of Object.entries(SKEL_DEFAULTS)) {
+                    // A value the current track never reads is left out
+                    // rather than sent and dropped, so what goes over the
+                    // wire is what the run can actually act on.  The setting
+                    // itself is kept, and returns when its track does.
+                    if (!applies(def)) continue;
                     if (key in skelParams && skelParams[key] !== def.value) {
                         params[key] = skelParams[key];
                     }
@@ -3692,11 +3748,62 @@ let meshCentroid = [0, 0, 0];
             function openSkelParams() {
                 const body = document.getElementById("skelParamsBody");
                 body.innerHTML = "";
-                for (const [key, def] of Object.entries(SKEL_DEFAULTS)) {
+
+                const note = document.createElement("div");
+                note.style.cssText =
+                    "grid-column:1/-1;color:#7fb3d5;font-size:11px;margin-bottom:6px;";
+                note.textContent =
+                    `${trackLabel(currentTrack)} — greyed parameters belong ` +
+                    `to the other track and are ignored on this one.`;
+                body.appendChild(note);
+
+                // Settings persist in localStorage across sessions, so this
+                // is the only place the page can say that what it shows is
+                // not what skeliner defaults to.
+                const nOver = Object.entries(SKEL_DEFAULTS).filter(
+                    ([k, d]) => k in skelParams && skelParams[k] !== d.value,
+                ).length;
+                if (nOver) {
+                    const warn = document.createElement("div");
+                    warn.style.cssText =
+                        "grid-column:1/-1;color:#e0b03c;font-size:11px;margin-bottom:6px;";
+                    warn.textContent =
+                        `${nOver} setting${nOver === 1 ? "" : "s"} (•) kept from an ` +
+                        `earlier session, not skeliner's default. Reset Defaults restores them.`;
+                    body.appendChild(warn);
+                }
+
+                // Applicable first: the dimmed ones are context, not the
+                // list you are meant to read past to reach the live settings.
+                const entries = Object.entries(SKEL_DEFAULTS).sort(
+                    (a, b) => applies(b[1]) - applies(a[1]),
+                );
+                for (const [key, def] of entries) {
+                    const live = applies(def);
                     const val = key in skelParams ? skelParams[key] : def.value;
+                    // A stored value renders exactly like a default, so a
+                    // setting changed in some earlier session reads as "this
+                    // is how skeliner ships" — which is how an unticked
+                    // second_pass got mistaken for a backend default.  Marked
+                    // instead, with the default it replaced.
+                    const overridden = key in skelParams && skelParams[key] !== def.value;
                     const label = document.createElement("label");
-                    label.textContent = def.label;
-                    label.style.color = "#ccc";
+                    label.textContent = def.label + (overridden ? " •" : "");
+                    label.style.color = !live ? "#666" : overridden ? "#e0b03c" : "#ccc";
+                    const why = [];
+                    if (!live) {
+                        why.push(
+                            "Only read when you " +
+                            def.tracks.map(trackLabel).join(" / ") + ".",
+                        );
+                    }
+                    if (overridden) {
+                        why.push(
+                            `Changed from the default (${def.value}) in an ` +
+                            `earlier session — Reset Defaults restores it.`,
+                        );
+                    }
+                    if (why.length) label.title = why.join(" ");
                     body.appendChild(label);
 
                     if (def.type === "bool") {
@@ -3704,6 +3811,7 @@ let meshCentroid = [0, 0, 0];
                         cb.type = "checkbox";
                         cb.checked = val;
                         cb.dataset.key = key;
+                        cb.disabled = !live;
                         cb.addEventListener("change", () => {
                             skelParams[key] = cb.checked;
                             localStorage.setItem('skeliner_skelParams', JSON.stringify(skelParams));
@@ -3714,8 +3822,11 @@ let meshCentroid = [0, 0, 0];
                         inp.type = "text";
                         inp.value = val;
                         inp.dataset.key = key;
+                        inp.disabled = !live;
                         inp.style.cssText =
-                            "width:80px;font-size:11px;font-family:monospace;background:#222;color:#ccc;border:1px solid #555;padding:2px 4px;";
+                            "width:80px;font-size:11px;font-family:monospace;background:#222;color:" +
+                            (live ? "#ccc" : "#666") +
+                            ";border:1px solid #555;padding:2px 4px;";
                         inp.addEventListener("change", () => {
                             skelParams[key] =
                                 def.type === "int" ? parseInt(inp.value) : parseFloat(inp.value);
@@ -5111,6 +5222,10 @@ let meshCentroid = [0, 0, 0];
                 ws.onopen = () => console.log("[skeliner] WebSocket connected");
                 ws.onmessage = (event) => {
                     const msg = JSON.parse(event.data);
+                    // Every broadcast carries the track, so the badge and the
+                    // dialog follow whatever last changed the components
+                    // without needing a message of their own.
+                    setTrack(msg.track);
                     if (msg.type === "annotations") applyAnnotations(msg.payload);
                     else if (msg.type === "annotations_updated") {
                         fetch("/annotations").then(r => r.json()).then(ann => {

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -573,6 +573,26 @@
                         <button id="skelCancelBtn" style="margin-left: 4px">Cancel</button>
                     </span>
                 </div>
+                <!-- Diagnostics list candidates and never edit.  Every
+                     threshold here is a heuristic with nothing validating it,
+                     so the cut is exposed rather than baked in: change it,
+                     re-run, and watch which nodes come and go.  Results land
+                     as markers, so the existing list gives focus, colour,
+                     visibility and remove for free — and focusing one selects
+                     its bin, which is what arms the verbs above. -->
+                <div style="white-space: nowrap; margin-top: 4px">
+                    <span style="color: #888" title="List candidates as markers to look at. Nothing here changes the skeleton.">Find:</span>
+                    <select id="dxKindSel" style="font-size: 11px; margin-left: 4px">
+                        <option value="junctions">merge candidates</option>
+                        <option value="twigs">short twigs</option>
+                        <option value="degree">high-degree nodes</option>
+                        <option value="tips">suspicious tips</option>
+                        <option value="orphans">unreachable nodes</option>
+                    </select>
+                    <span id="dxParams" style="margin-left: 6px"></span>
+                    <button id="dxRunBtn" style="margin-left: 6px">List</button>
+                    <span id="dxStatus" style="margin-left: 8px; color: #888"></span>
+                </div>
                 <div
                     id="binReadout"
                     style="margin-top: 4px; color: #888; white-space: nowrap; overflow-x: auto"
@@ -1082,6 +1102,12 @@ let meshCentroid = [0, 0, 0];
                 document.getElementById("binMergeBtn").addEventListener("click", runBinMerge);
                 document.getElementById("binSplitBtn").addEventListener("click", runBinSplit);
                 document.getElementById("edgeEditBtn").addEventListener("click", runEdgeEdit);
+                document.getElementById("dxKindSel").addEventListener("change", () => {
+                    renderDxParams();
+                    document.getElementById("dxStatus").textContent = "";
+                });
+                document.getElementById("dxRunBtn").addEventListener("click", runDiagnostic);
+                renderDxParams();
                 document.getElementById("skelApplyBtn").addEventListener("click", runSkelApply);
                 document.getElementById("skelCancelBtn").addEventListener("click", runSkelCancel);
                 document.getElementById("scopeAllBtn").addEventListener("click", () => setScopeAll(true));
@@ -3039,6 +3065,94 @@ let meshCentroid = [0, 0, 0];
              * told from a restore to a graft, and those are different claims.
              * ~15 ms on a 583-node cell, ~110 ms on an 11k-node one.
              */
+            // ── Diagnostics ──────────────────────────────────────────────────
+            // Each entry declares the cuts it exposes.  They are inputs rather
+            // than constants because no value here is settled: the corpus can
+            // rank candidates but cannot say which are real, so the honest
+            // interface is one you can turn and watch.
+            const DX_PARAMS = {
+                junctions: [
+                    { id: "minDegree", label: "deg≥", value: 4, size: 2,
+                      title: "Minimum graph degree to consider at all." },
+                    { id: "minCable", label: "arm≥", value: 5, size: 4,
+                      title: "How much cable a distal arm must carry to count as substantial, in um. Two arms must clear it independently." },
+                    { id: "minComponents", label: "arms", value: 2, size: 2,
+                      title: "How many distal arms must clear the bar." },
+                ],
+                twigs: [
+                    { id: "maxRatio", label: "≤", value: 3, size: 3,
+                      title: "Twig cable as a multiple of the radius of the branch node it hangs off. Small means the twig is shorter than its host is thick." },
+                    { id: "maxNodes", label: "nodes≤", value: 3, size: 2,
+                      title: "Longest twig, in nodes, to list." },
+                ],
+                degree: [
+                    { id: "minDegree", label: "deg≥", value: 4, size: 2,
+                      title: "List every node at or above this degree." },
+                ],
+                tips: [
+                    { id: "nearFactor", label: "near", value: 1.2, size: 3,
+                      title: "Multiple of the largest soma semi-axis inside which a tip counts as close." },
+                    { id: "pathRatio", label: "path≥", value: 2.0, size: 3,
+                      title: "Minimum path-length / straight-line ratio." },
+                ],
+                orphans: [],
+            };
+
+            function renderDxParams() {
+                const kind = document.getElementById("dxKindSel").value;
+                const host = document.getElementById("dxParams");
+                host.innerHTML = "";
+                for (const p of DX_PARAMS[kind] || []) {
+                    const lab = document.createElement("span");
+                    lab.style.color = "#888";
+                    lab.style.marginLeft = "6px";
+                    lab.textContent = p.label;
+                    lab.title = p.title;
+                    const inp = document.createElement("input");
+                    inp.type = "text";
+                    inp.id = "dxp_" + p.id;
+                    inp.value = p.value;
+                    inp.size = p.size;
+                    inp.title = p.title;
+                    inp.style.marginLeft = "3px";
+                    inp.style.fontSize = "11px";
+                    host.appendChild(lab);
+                    host.appendChild(inp);
+                }
+            }
+
+            async function runDiagnostic() {
+                const kind = document.getElementById("dxKindSel").value;
+                const sname = document.getElementById("binSkelSel").value;
+                const status = document.getElementById("dxStatus");
+                const btn = document.getElementById("dxRunBtn");
+                if (!sname) {
+                    status.textContent = "no skeleton";
+                    return;
+                }
+                const params = {};
+                for (const p of DX_PARAMS[kind] || []) {
+                    const el = document.getElementById("dxp_" + p.id);
+                    if (el) params[p.id] = parseFloat(el.value);
+                }
+                btn.disabled = true;
+                status.textContent = "…";
+                try {
+                    const r = await fetch("/diagnose", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ name: sname, kind, params }),
+                    });
+                    const data = await r.json();
+                    status.textContent = data.ok
+                        ? `${data.n} found — open Annotations to step through`
+                        : data.error || "error";
+                } catch (e) {
+                    status.textContent = "error: " + e.message;
+                }
+                btn.disabled = false;
+            }
+
             async function fetchEdgeSupport() {
                 const sname = document.getElementById("binSkelSel").value;
                 if (panelMode !== "skeleton" || !sname) {

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -591,6 +591,7 @@
                              and the panel neither renames nor resequences
                              what the library already settled. -->
                         <option value="orphans">isolated nodes</option>
+                        <option value="cycles">cycles</option>
                         <option value="degree">nodes of degree</option>
                         <option value="twigs">short twigs</option>
                         <option value="tips">suspicious tips</option>
@@ -3080,6 +3081,7 @@ let meshCentroid = [0, 0, 0];
             // Keys are in the dropdown's order, which is dx.__skeleton__'s.
             const DX_PARAMS = {
                 orphans: [],
+                cycles: [],
                 degree: [
                     { id: "minDegree", label: "deg≥", value: 4, size: 2,
                       title: "List every node at or above this degree." },
@@ -4833,11 +4835,19 @@ let meshCentroid = [0, 0, 0];
                         }
                         const geo = new THREE.BufferGeometry();
                         geo.setAttribute("position", new THREE.BufferAttribute(pts, 3));
+                        // A group flagged `overlay` traces edges the skeleton
+                        // already draws, so at equal depth it z-fights with
+                        // them and the highlight is only visible once the
+                        // skeleton is hidden — which takes away the context
+                        // it exists to be seen against.  Draw it on top.
                         const mat = new THREE.LineBasicMaterial({
                             color: new THREE.Color(color[0], color[1], color[2]),
                             linewidth: 2,
+                            depthTest: !group.overlay,
+                            transparent: !!group.overlay,
                         });
                         const line = new THREE.LineSegments(geo, mat);
+                        if (group.overlay) line.renderOrder = 10;
                         scene.add(line);
                         edgeGroupMeshes.push(line);
                     }

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -388,40 +388,43 @@
         </div>
 
         <div id="detect-panel">
-            <!-- Which stage of the workflow the rows below belong to, and
-                 nothing else.  A verb parked on this row reads as part of
-                 the mode selector; the ones that work in every mode live in
-                 the footer at the bottom of the panel instead. -->
+            <!-- Which object the rows below edit, and nothing else.  The
+                 three are the derivation chain — the mesh, the components
+                 broken out of it, the skeleton built from those — so naming
+                 them after the object states both what a row may change and
+                 what it leaves alone.  A verb parked on this row reads as a
+                 fourth mode; the ones that work on every object live in the
+                 footer at the bottom of the panel instead. -->
             <div style="white-space: nowrap">
-                <span style="color: #888">Mode:</span>
+                <span style="color: #888">Edit:</span>
                 <button
-                    id="modePreprocessBtn"
+                    id="modeMeshBtn"
                     class="mode-btn"
                     style="margin-left: 4px"
                     data-active="1"
-                    title="Run the automatic pipeline"
+                    title="Change the mesh itself — its faces and vertices. Detect and remove defects one at a time, or run the whole pipeline at once."
                 >
-                    Preprocess
+                    Mesh
                 </button>
                 <button
-                    id="modeEditBtn"
+                    id="modeCompBtn"
                     class="mode-btn"
                     style="margin-left: 4px"
-                    title="Hand faces between components — needs Break first"
+                    title="Change which component owns a face — soma, organelle, neurite or discarded. The geometry is left alone. Needs Break first."
                 >
-                    Edit Mesh
+                    Mesh Comp.
                 </button>
                 <button
                     id="modeSkelBtn"
                     class="mode-btn"
                     style="margin-left: 4px"
-                    title="Edit the bins the neurites are partitioned into, and the edges between them — needs Skeletonize first"
+                    title="Change the bins the neurites are partitioned into, and the edges between them — needs Skeletonize first"
                 >
-                    Edit Skeleton
+                    Skeleton
                 </button>
             </div>
 
-            <div id="preprocess-rows">
+            <div id="mesh-rows">
                 <div style="white-space: nowrap; margin-top: 4px">
                     <span style="color: #888">Detect:</span>
                     <button id="detectParallelBtn" style="margin-left:4px">Parallel</button>
@@ -460,7 +463,7 @@
                 </div>
             </div>
 
-            <div id="editmesh-rows" style="display: none">
+            <div id="components-rows" style="display: none">
                 <div style="white-space: nowrap; margin-top: 4px">
                     <span style="color: #888" title="Only faces of a lit component can be picked">Scope:</span>
                     <span id="scopeChips"></span>
@@ -517,7 +520,7 @@
                 </div>
             </div>
 
-            <div id="editskel-rows" style="display: none">
+            <div id="skeleton-rows" style="display: none">
                 <div style="white-space: nowrap; margin-top: 4px">
                     <span style="color: #888" title="Which loaded skeleton the bin and edge edits below act on">Editing:</span>
                     <select id="binSkelSel" style="font-size: 11px; margin-left: 4px"></select>
@@ -1061,14 +1064,14 @@ let meshCentroid = [0, 0, 0];
                 document.getElementById("reassignApplyBtn").addEventListener("click", applyReassign);
                 document.getElementById("reassignCancelBtn").addEventListener("click", cancelReassign);
                 document
-                    .getElementById("modePreprocessBtn")
-                    .addEventListener("click", () => setMode("preprocess"));
+                    .getElementById("modeMeshBtn")
+                    .addEventListener("click", () => setMode("mesh"));
                 document
-                    .getElementById("modeEditBtn")
-                    .addEventListener("click", () => setMode("editmesh"));
+                    .getElementById("modeCompBtn")
+                    .addEventListener("click", () => setMode("components"));
                 document
                     .getElementById("modeSkelBtn")
-                    .addEventListener("click", () => setMode("editskel"));
+                    .addEventListener("click", () => setMode("skeleton"));
                 document.getElementById("binSkelSel").addEventListener("change", () => {
                     clearBinSelection();
                     fetchEdgeSupport();
@@ -1610,7 +1613,7 @@ let meshCentroid = [0, 0, 0];
                 // so this is the one place that has to notice.  Which pairs
                 // the tree already has is a function of this layer's edges, so
                 // it is re-asked when *this* layer is the one being looked at.
-                if (panelMode === "editskel") {
+                if (panelMode === "skeleton") {
                     refreshBinSkelSel();
                     if (document.getElementById("binSkelSel").value === name)
                         fetchEdgeSupport();
@@ -1813,9 +1816,9 @@ let meshCentroid = [0, 0, 0];
                     const radius = skelNodeRadii ? skelNodeRadii[nodeIndex] : null;
                     const key = `${bestSkelName}:${nodeIndex}`;
 
-                    // In Edit Skeleton a node is shown as the surface it
+                    // In the Skeleton panel a node is shown as the surface it
                     // owns, not as a ball: the bin is what a node actually is.
-                    if (panelMode === "editskel") {
+                    if (panelMode === "skeleton") {
                         const sel = document.getElementById("binSkelSel");
                         // Node ids mean different things in different layers,
                         // so a click that switches layer starts a new
@@ -1884,7 +1887,7 @@ let meshCentroid = [0, 0, 0];
                 // shift-click adjusts the face selection here as it does
                 // everywhere else.  Letting it pick a bin as well gave one
                 // modifier two meanings in the mode where both are live.
-                if (panelMode === "editskel" && !event.shiftKey) {
+                if (panelMode === "skeleton" && !event.shiftKey) {
                     selectBin(faceIndex, true);
                     return;
                 }
@@ -2279,54 +2282,54 @@ let meshCentroid = [0, 0, 0];
                 );
             }
 
-            // ── Edit Mesh mode ───────────────────────────────────────────
-            // The two panels are different activities — run the automatic
+            // ── Mode selector ────────────────────────────────────────────
+            // Three modes, one per object in the derivation chain: the mesh,
+            // the components broken out of it, then the skeleton built from
+            // those.  They are also different activities — run the automatic
             // steps in order, versus select/assign/commit — and separating
             // them is what keeps a lasso from meaning two things.
-            // Three modes, because they are the workflow stages: run the
-            // automatic steps, then correct the components, then correct the
-            // partition.  `editMode` stays a boolean for Edit Mesh so the
-            // scope block below reads exactly one thing.
-            let panelMode = "preprocess"; // preprocess | editmesh | editskel
-            let editMode = false;
+            // `componentMode` stays a boolean because the scope block below
+            // reads exactly one of the three.
+            let panelMode = "mesh"; // mesh | components | skeleton
+            let componentMode = false;
 
             const MODE_ROWS = {
-                preprocess: "preprocess-rows",
-                editmesh: "editmesh-rows",
-                editskel: "editskel-rows",
+                mesh: "mesh-rows",
+                components: "components-rows",
+                skeleton: "skeleton-rows",
             };
             const MODE_BTNS = {
-                preprocess: "modePreprocessBtn",
-                editmesh: "modeEditBtn",
-                editskel: "modeSkelBtn",
+                mesh: "modeMeshBtn",
+                components: "modeCompBtn",
+                skeleton: "modeSkelBtn",
             };
 
             function setMode(mode) {
-                // Preprocess and Edit Mesh both read a selection as faces to
-                // operate on; Edit Skeleton reads it as surface to move
-                // between bins.  Carrying one across that line would hand the
-                // new mode a selection made under the other's scope.
-                if ((panelMode === "editskel") !== (mode === "editskel")) {
+                // Mesh and Mesh Comp. both read a selection as faces to
+                // operate on; Skeleton reads it as surface to move between
+                // bins.  Carrying one across that line would hand the new
+                // mode a selection made under the other's scope.
+                if ((panelMode === "skeleton") !== (mode === "skeleton")) {
                     manualHighlightFaces.clear();
                     rebuildManualHighlight();
                     syncManualHighlight();
                 }
                 panelMode = mode;
-                editMode = mode === "editmesh";
+                componentMode = mode === "components";
                 for (const [m, id] of Object.entries(MODE_ROWS))
                     document.getElementById(id).style.display =
                         m === mode ? "block" : "none";
                 for (const [m, id] of Object.entries(MODE_BTNS))
                     document.getElementById(id).dataset.active = m === mode ? "1" : "0";
 
-                // Scoping is an Edit Mesh notion; leaving a mask applied on the
+                // Scoping is a Mesh Comp. notion; leaving a mask applied on the
                 // way out would silently narrow selection in a panel with no
-                // scope UI to explain it.  rebuildScopeMask reads editMode.
+                // scope UI to explain it.  rebuildScopeMask reads componentMode.
                 rebuildScopeMask();
-                if (editMode) renderScopeChips();
+                if (componentMode) renderScopeChips();
                 else cancelReassign();
 
-                if (mode === "editskel") {
+                if (mode === "skeleton") {
                     refreshBinSkelSel();
                     // The edge verb cannot be named without knowing which
                     // pairs the surface supports, so this is not optional.
@@ -2345,7 +2348,7 @@ let meshCentroid = [0, 0, 0];
             //
             // scopeOn is an allow-list of indices into
             // currentAnnotations.highlights.  `null` means "not chosen yet",
-            // which shows every chip lit and behaves like Preprocess does; an
+            // which shows every chip lit and behaves like Mesh does; an
             // *empty* set is a deliberate choice that nothing is pickable.
             // Keeping those two apart is what lets "All" and "None" be
             // different buttons rather than two ways to say the same thing.
@@ -2354,7 +2357,7 @@ let meshCentroid = [0, 0, 0];
             // the lookup is the lasso's inner loop, over every face.
             let scopeMask = null; // null → unscoped, everything pickable
             let scopeOn = null;
-            // Edit Skeleton's scope, filled in by rebuildBinScopeMask.  Here
+            // Skeleton's scope, filled in by rebuildBinScopeMask.  Here
             // rather than with the bin code because inScope is the one pick
             // path both modes go through, and a scope it cannot see is a scope
             // that silently does not apply.  Note `null` means the opposite of
@@ -2374,7 +2377,7 @@ let meshCentroid = [0, 0, 0];
             }
 
             function rebuildScopeMask() {
-                if (!editMode || scopeOn === null || !meshGeometry) {
+                if (!componentMode || scopeOn === null || !meshGeometry) {
                     scopeMask = null;
                     return;
                 }
@@ -2386,12 +2389,12 @@ let meshCentroid = [0, 0, 0];
                 }
             }
 
-            // Two modes, two scopes, one pick path.  Edit Mesh bounds the
-            // lasso by component; Edit Skeleton bounds it by the destination
+            // Two modes, two scopes, one pick path.  Mesh Comp. bounds the
+            // lasso by component; Skeleton bounds it by the destination
             // bin's graph neighbours, which is a correctness constraint and
             // not only a convenience — see binScopeMask.
             function inScope(faceIndex) {
-                if (panelMode === "editskel") {
+                if (panelMode === "skeleton") {
                     return binScopeMask !== null && binScopeMask[faceIndex] === 1;
                 }
                 return scopeMask === null || scopeMask[faceIndex] === 1;
@@ -2533,7 +2536,7 @@ let meshCentroid = [0, 0, 0];
                 // different components than the user lit.
                 scopeOn = null;
                 rebuildScopeMask();
-                if (editMode) renderScopeChips();
+                if (componentMode) renderScopeChips();
             }
 
             // ── Rescue discarded fragments ───────────────────────────────
@@ -2713,7 +2716,7 @@ let meshCentroid = [0, 0, 0];
                 document.getElementById("reassignSummary").style.display = "none";
             }
 
-            // ── Bin selection (Edit Skeleton) ───────────────────────────
+            // ── Bin selection (Edit ▸ Skeleton) ─────────────────────────
             // A node *is* the set of mesh vertices it owns: its position is
             // their centroid and every radius is an aggregate over them.  So
             // in this mode a selected node renders as the surface it owns
@@ -3038,7 +3041,7 @@ let meshCentroid = [0, 0, 0];
              */
             async function fetchEdgeSupport() {
                 const sname = document.getElementById("binSkelSel").value;
-                if (panelMode !== "editskel" || !sname) {
+                if (panelMode !== "skeleton" || !sname) {
                     clearEdgeSupport();
                     return;
                 }

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -1313,20 +1313,27 @@ let meshCentroid = [0, 0, 0];
                     dragCounter = 0;
                     overlay.style.display = "none";
 
-                    for (const file of e.dataTransfer.files) {
-                        const formData = new FormData();
-                        formData.append("file", file);
-                        try {
-                            const resp = await fetch("/upload", { method: "POST", body: formData });
-                            const data = await resp.json();
-                            if (data.ok) {
-                                console.log(`[skeliner] Loaded ${data.type}: ${data.name}`);
-                            } else {
-                                console.error(`[skeliner] Upload failed: ${data.error}`);
+                    // One drop is one gesture: the files go up together so the
+                    // server can order them by type and clear the previous
+                    // session once, instead of a mesh arriving second and
+                    // wiping the components that came with it.
+                    const files = [...e.dataTransfer.files];
+                    if (!files.length) return;
+                    const formData = new FormData();
+                    for (const file of files) formData.append("files", file);
+                    try {
+                        const resp = await fetch("/upload_batch", { method: "POST", body: formData });
+                        const data = await resp.json();
+                        if (data.ok) {
+                            for (const r of data.results) {
+                                if (r.ok) console.log(`[skeliner] Loaded ${r.type}: ${r.name}`);
+                                else console.error(`[skeliner] Failed ${r.name}: ${r.error}`);
                             }
-                        } catch (err) {
-                            console.error("[skeliner] Upload error:", err);
+                        } else {
+                            console.error(`[skeliner] Upload failed: ${data.error}`);
                         }
+                    } catch (err) {
+                        console.error("[skeliner] Upload error:", err);
                     }
                 });
             }

--- a/skeliner/plot/viewer.html
+++ b/skeliner/plot/viewer.html
@@ -4455,11 +4455,23 @@ let meshCentroid = [0, 0, 0];
                     mouse.y = -(upEvent.clientY / window.innerHeight) * 2 + 1;
                     raycaster.setFromCamera(mouse, camera);
                     const targets = [];
-                    if (meshObj) targets.push(meshObj);
+                    if (meshObj && meshObj.visible) targets.push(meshObj);
                     for (const em of Object.values(extraMeshObjs)) {
                         if (em && em.mesh) targets.push(em.mesh);
                     }
+                    // Skeleton nodes are recentre targets in their own right.
+                    // Without them, hiding the mesh to see a junction — the
+                    // reason anyone hides it — also takes away the only way to
+                    // navigate to one, and a skeleton loaded on its own has no
+                    // recentre at all.  The mesh is skipped while hidden for
+                    // the same reason: it would otherwise keep winning the
+                    // depth test against the nodes it is drawn over.
+                    for (const sg of Object.values(skelGroups)) {
+                        if (sg && sg.nodePoints && sg.group.visible) targets.push(sg.nodePoints);
+                    }
                     if (targets.length === 0) return;
+                    raycaster.params.Points.threshold =
+                        camera.position.distanceTo(controls.target) * 0.02;
                     let best = null;
                     for (const t of targets) {
                         const h = raycaster.intersectObject(t);
@@ -4820,6 +4832,44 @@ let meshCentroid = [0, 0, 0];
                 scheduleStateUpdate();
             }
 
+            // A marker is a point, so unlike the other two channels there is
+            // no extent to frame — the distance comes from the marker's own
+            // radius, with a floor so a small one does not put the camera
+            // inside it.
+            //
+            // A marker carrying `node` is a *skeleton node*, which is what a
+            // diagnostic emits: flying there and leaving the node unselected
+            // would make every row a two-step gesture, and the second step is
+            // finding a bin you are already looking at.  So focusing one also
+            // selects its bin, which is what arms the edit verbs.  Cleared
+            // first rather than toggled, so focusing the same row twice is
+            // idempotent instead of deselecting.
+            function focusOnMarker(idx) {
+                const sphere = markerMeshes[idx];
+                if (!sphere) return;
+                const mk = (currentAnnotations.markers || [])[idx] || {};
+                const center = sphere.position.clone();
+
+                const offset = camera.position.clone().sub(controls.target).normalize();
+                controls.target.copy(center);
+                camera.position
+                    .copy(center)
+                    .addScaledVector(offset, Math.max((mk.radius || 50) * 6, 500));
+                controls.update();
+                scheduleStateUpdate();
+
+                if (mk.node == null || panelMode !== "skeleton") return;
+                const sel = document.getElementById("binSkelSel");
+                if (mk.skelName && sel.value !== mk.skelName && skelGroups[mk.skelName]) {
+                    sel.value = mk.skelName;
+                    clearBinSelection();
+                    fetchEdgeSupport();
+                } else {
+                    clearBinSelection();
+                }
+                selectBin(mk.node);
+            }
+
             function removeEdgeGroup(idx) {
                 if (!currentAnnotations || !currentAnnotations.edge_groups) return;
                 currentAnnotations.edge_groups.splice(idx, 1);
@@ -4972,7 +5022,33 @@ let meshCentroid = [0, 0, 0];
                         const div = document.createElement("div");
                         div.className = "hl-item";
                         const rgb = `rgb(${Math.round(color[0] * 255)},${Math.round(color[1] * 255)},${Math.round(color[2] * 255)})`;
-                        div.innerHTML = `<span><span class="hl-swatch" style="background:${rgb}; border-radius:50%"></span>${label}</span>`;
+                        const left = document.createElement("span");
+                        const swatch = document.createElement("span");
+                        swatch.className = "hl-swatch";
+                        swatch.style.cssText = `background:${rgb}; border-radius:50%`;
+                        left.appendChild(swatch);
+                        // A marker naming a node says so, since the id is what
+                        // a diagnostic reports and what the reader has to
+                        // match against a list elsewhere.
+                        const nameSpan = document.createElement("span");
+                        nameSpan.textContent =
+                            label + (mk.node != null ? ` · node ${mk.node}` : "");
+                        nameSpan.title =
+                            mk.node != null
+                                ? "Double-click to centre on this node and select its bin"
+                                : "Double-click to centre on this marker";
+                        nameSpan.style.cssText =
+                            "cursor:pointer;border-bottom:1px dashed #555;";
+                        nameSpan.addEventListener("dblclick", () => focusOnMarker(idx));
+                        left.appendChild(nameSpan);
+                        div.appendChild(left);
+
+                        const focusBtn = document.createElement("button");
+                        focusBtn.className = "icon-btn";
+                        focusBtn.textContent = "⌖";
+                        focusBtn.title = "Center camera on this marker";
+                        focusBtn.addEventListener("click", () => focusOnMarker(idx));
+                        div.appendChild(focusBtn);
 
                         const toggleBtn = document.createElement("button");
                         toggleBtn.className = "toggle-vis icon-btn";

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -4314,10 +4314,11 @@ def _create_app(
         )
 
     #: Diagnostics offered in the skeleton panel.  Each returns a list of
-    #: ``(node_id, label)``; the route turns them into markers.  They are
-    #: *candidate listers* — none of them edits, and none of them ranks by a
-    #: threshold the corpus has not justified, so every cut is a parameter
-    #: the user sets and can see the effect of.
+    #: ``{"node", "detail"}``, optionally with ``"cut"`` / ``"keep"`` edge
+    #: lists which the route draws.  They are *candidate listers* — none of
+    #: them edits, and none of them ranks by a threshold the corpus has not
+    #: justified, so every cut is a parameter the user sets and can see the
+    #: effect of.
     def _dx_junctions(skel, p):
         from skeliner import dx
 
@@ -4329,11 +4330,22 @@ def _create_app(
             min_components=int(p.get("minComponents", 2)),
             return_stats=True,
         )
+        # Lists junctions and what each arm carries.  It proposes no cut:
+        # `arm_pairing` used to ride along here and was removed, because its
+        # score is purely directional and cannot tell a 0.8 um binning stub
+        # from a 261 um dendrite — so it paired stubs with major arms and
+        # ranked its most destructive proposals highest.  See
+        # `.claude/labbook/2026-08-11-arm-pairing-retracted.md`.
         out = []
         for nid in flagged:
             d = sorted(stats[nid]["distal_cables"], reverse=True)
             arms = ", ".join(f"{c / 1000:.1f}" for c in d[:4])
-            out.append((nid, f"deg {stats[nid]['degree']} · arms {arms} um"))
+            out.append(
+                {
+                    "node": nid,
+                    "detail": f"deg {stats[nid]['degree']} · arms {arms} um",
+                }
+            )
         return out
 
     def _dx_short_twigs(skel, p):
@@ -4394,13 +4406,19 @@ def _create_app(
             if ratio > max_ratio:
                 continue
             out.append(
-                (
-                    leaf,
-                    f"{len(chain)}-node twig · {cable / 1000:.2f} um "
-                    f"= {ratio:.1f}x host radius (node {u})",
-                )
+                {
+                    "node": leaf,
+                    "detail": (
+                        f"{len(chain)}-node twig · {cable / 1000:.2f} um "
+                        f"= {ratio:.1f}x host radius (node {u})"
+                    ),
+                    "ratio": ratio,
+                    # The twig itself, so the candidate is a visible stretch
+                    # of cable rather than a dot you have to trace by eye.
+                    "cut": [(c, int(par[c])) for c in chain],
+                }
             )
-        out.sort(key=lambda t: float(t[1].split("= ")[1].split("x")[0]))
+        out.sort(key=lambda r: r["ratio"])
         return out
 
     def _dx_degree(skel, p):
@@ -4410,7 +4428,7 @@ def _create_app(
         out = []
         for d in range(k, 12):
             for nid in dx.nodes_of_degree(skel, d):
-                out.append((int(nid), f"degree {d}"))
+                out.append({"node": int(nid), "detail": f"degree {d}"})
         return out
 
     def _dx_orphans(skel, _p):
@@ -4419,7 +4437,7 @@ def _create_app(
         iso = dx.check_connectivity(skel, return_isolated=True)
         if iso is True:
             return []
-        return [(int(nid), "unreachable from soma") for nid in iso]
+        return [{"node": int(nid), "detail": "unreachable from soma"} for nid in iso]
 
     def _dx_tips(skel, p):
         from skeliner import dx
@@ -4429,14 +4447,21 @@ def _create_app(
             near_factor=float(p.get("nearFactor", 1.2)),
             path_ratio_thresh=float(p.get("pathRatio", 2.0)),
         )
-        return [(int(nid), "tip near soma, long path") for nid in tips]
+        return [
+            {"node": int(nid), "detail": "tip near soma, long path"} for nid in tips
+        ]
 
+    #: Named after the `dx` function each one runs, and ordered the way
+    #: `dx.__skeleton__` orders them — the one invariant check, then the
+    #: plain enumerations, then the heuristics.  Both so that what the panel
+    #: calls a thing and what the library calls it cannot drift apart, and
+    #: so the list reads from "this is broken" to "this might repay a look".
     DIAGNOSTICS = {
-        "junctions": ("merge candidates", [0.95, 0.35, 0.25], _dx_junctions),
+        "orphans": ("isolated nodes", [0.9, 0.3, 0.9], _dx_orphans),
+        "degree": ("nodes of degree", [0.95, 0.75, 0.2], _dx_degree),
         "twigs": ("short twigs", [0.35, 0.75, 0.95], _dx_short_twigs),
-        "degree": ("high-degree nodes", [0.95, 0.75, 0.2], _dx_degree),
-        "orphans": ("unreachable nodes", [0.9, 0.3, 0.9], _dx_orphans),
         "tips": ("suspicious tips", [0.4, 0.9, 0.5], _dx_tips),
+        "junctions": ("suspicious junctions", [0.95, 0.35, 0.25], _dx_junctions),
     }
 
     async def diagnose(request):
@@ -4479,18 +4504,52 @@ def _create_app(
         # from raw node coordinates lands a whole centroid away, which on CAVE
         # cells is hundreds of microns off screen.
         centroid = np.asarray(mesh_state["centroid"], dtype=np.float64)
+
+        def _seg(u, v):
+            return [
+                [float(x) for x in (skel.nodes[int(u)] - centroid)],
+                [float(x) for x in (skel.nodes[int(v)] - centroid)],
+            ]
+
         radii = skel.r
-        markers = []
-        for nid, detail in found:
+        markers, cut_segs, keep_segs = [], [], []
+        for row in found:
+            nid = int(row["node"])
             r = float(radii[nid]) if nid < len(radii) else 0.0
             markers.append(
                 {
                     "position": [float(x) for x in (skel.nodes[nid] - centroid)],
                     "color": color,
                     "radius": max(r * 2.5, 150.0),
-                    "label": f"{label}: {detail}",
+                    "label": f"{label}: {row['detail']}",
                     "skelName": name,
-                    "node": int(nid),
+                    "node": nid,
+                    "dx": kind,
+                }
+            )
+            cut_segs.extend(_seg(u, v) for u, v in row.get("cut", ()))
+            keep_segs.extend(_seg(u, v) for u, v in row.get("keep", ()))
+
+        # A proposal about which branches to sever is a statement about
+        # geometry, so it is drawn on the geometry.  Named only in the label,
+        # "cut 79+84" leaves the eye to resolve two node ids into two
+        # branches — the one job the viewer exists to do.
+        groups = []
+        if cut_segs:
+            groups.append(
+                {
+                    "segments": cut_segs,
+                    "color": [1.0, 0.25, 0.25],
+                    "label": f"{label}: proposed cut ({len(cut_segs)} edges)",
+                    "dx": kind,
+                }
+            )
+        if keep_segs:
+            groups.append(
+                {
+                    "segments": keep_segs,
+                    "color": [0.3, 0.9, 0.4],
+                    "label": f"{label}: cable that continues ({len(keep_segs)} edges)",
                     "dx": kind,
                 }
             )
@@ -4498,13 +4557,24 @@ def _create_app(
         ann = {}
         if annotations_path.exists():
             ann = json.loads(annotations_path.read_text(encoding="utf-8"))
-        kept = [m for m in ann.get("markers", []) if m.get("dx") != kind]
-        ann["markers"] = kept + markers
+        ann["markers"] = [
+            m for m in ann.get("markers", []) if m.get("dx") != kind
+        ] + markers
+        ann["edge_groups"] = [
+            g for g in ann.get("edge_groups", []) if g.get("dx") != kind
+        ] + groups
         annotations_path.write_text(json.dumps(ann), encoding="utf-8")
         await broadcast({"type": "annotations_updated"})
 
         await _log(f"[skeliner.dx] {label}: {len(markers)} candidate(s) on '{name}'")
-        return JSONResponse({"ok": True, "kind": kind, "n": len(markers)})
+        return JSONResponse(
+            {
+                "ok": True,
+                "kind": kind,
+                "n": len(markers),
+                "nCut": len(cut_segs),
+            }
+        )
 
     async def edge_edit_preview(request):
         """Work out what clipping or grafting one edge would do.

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -488,8 +488,21 @@ def _create_app(
     _UNDO_LIMIT = 10
 
     # ── Broadcast helper ──────────────────────────────────────────────
+    def _current_track() -> str:
+        """Which track ``/skeletonize`` would take if pressed right now.
+
+        Asked in one place so that the label the user reads and the branch
+        that actually runs cannot disagree — ``run_skeletonize`` reads this
+        too rather than repeating the test.
+        """
+        return "preprocessing" if mesh_state.get("neurites") is not None else "direct"
+
     async def broadcast(msg: dict):
-        data = json.dumps(msg)
+        # Stamped on the way out rather than announced by whoever changed the
+        # components: six places publish them and three drop them, and the
+        # track is derived from state anyway.  A message that carries it
+        # cannot be the one site that forgot to send it.
+        data = json.dumps({**msg, "track": _current_track()})
         for ws in connected_clients:
             try:
                 await ws.send_text(data)
@@ -592,7 +605,9 @@ def _create_app(
 
     async def get_loaded(_request):
         """Return what's currently loaded."""
-        result = {"mesh": None, "skeletons": {}}
+        # The page asks once on load; after that the track rides on every
+        # broadcast, so this is the starting value rather than the channel.
+        result = {"mesh": None, "skeletons": {}, "track": _current_track()}
         if mesh_state["path"]:
             result["mesh"] = {
                 "path": mesh_state["path"],
@@ -3586,8 +3601,10 @@ def _create_app(
         params = body.get("params", {})
         mesh = mesh_state["mesh"]
 
-        # If break_up_mesh has run, use the preprocessing track
-        if mesh_state.get("neurites") is not None:
+        # If break_up_mesh has run, use the preprocessing track.  Asked of
+        # _current_track so the panel cannot label one track and run the other.
+        track = _current_track()
+        if track == "preprocessing":
             from skeliner.dataclass import (
                 Discarded,
                 MeshComponents,
@@ -3640,6 +3657,10 @@ def _create_app(
                 "ok": True,
                 "nNodes": len(skel.nodes),
                 "nEdges": len(skel.edges),
+                # Which track produced this one.  Reported rather than
+                # inferred by the client, so a run and its label agree even
+                # if the components changed while it was working.
+                "ranTrack": track,
             }
         )
 

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -4343,7 +4343,7 @@ def _create_app(
             out.append(
                 {
                     "node": nid,
-                    "detail": f"deg {stats[nid]['degree']} · arms {arms} um",
+                    "detail": f"deg {stats[nid]['degree']} · arms {arms} µm",
                 }
             )
         return out
@@ -4409,13 +4409,17 @@ def _create_app(
                 {
                     "node": leaf,
                     "detail": (
-                        f"{len(chain)}-node twig · {cable / 1000:.2f} um "
-                        f"= {ratio:.1f}x host radius (node {u})"
+                        f"{len(chain)}-node twig · {cable / 1000:.2f} µm "
+                        f"= {ratio:.1f}× host radius (node {u})"
                     ),
                     "ratio": ratio,
-                    # The twig itself, so the candidate is a visible stretch
-                    # of cable rather than a dot you have to trace by eye.
-                    "cut": [(c, int(par[c])) for c in chain],
+                    # No edges drawn.  Ninety scattered twigs pooled into one
+                    # annotation cannot be focused (they are all over the
+                    # cell) and cannot be acted on together (most of them are
+                    # real branches), so the group is noise in the list.
+                    # Edges are worth drawing when they form one thing you
+                    # trace — a loop — not N unrelated fragments; a twig is
+                    # already at the marker you focused.
                 }
             )
         out.sort(key=lambda r: r["ratio"])
@@ -4469,7 +4473,7 @@ def _create_app(
             n_break = len(cyc["breaks"])
             detail = (
                 f"loop of {len(cyc['nodes'])} nodes, "
-                f"{cyc['length'] / 1000:.1f} um · "
+                f"{cyc['length'] / 1000:.1f} µm · "
                 + (
                     f"{n_break} edge(s) the surface does not support"
                     if n_break
@@ -4516,12 +4520,7 @@ def _create_app(
             ("no surface behind it", "the loop"),
         ),
         "degree": ("nodes of degree", [0.95, 0.75, 0.2], _dx_degree, None),
-        "twigs": (
-            "short twigs",
-            [0.35, 0.75, 0.95],
-            _dx_short_twigs,
-            ("the twig", None),
-        ),
+        "twigs": ("short twigs", [0.35, 0.75, 0.95], _dx_short_twigs, None),
         "tips": ("suspicious tips", [0.4, 0.9, 0.5], _dx_tips, None),
         "junctions": (
             "suspicious junctions",
@@ -4587,11 +4586,17 @@ def _create_app(
                 {
                     "position": [float(x) for x in (skel.nodes[nid] - centroid)],
                     "color": color,
-                    # A marker says "look here", so its size is about being
-                    # findable, not about the node.  Scaled by the node's own
-                    # radius it is a 20 um ball on the soma, which hides the
-                    # very structure it is pointing at.
-                    "radius": min(max(r * 2.5, 150.0), 1200.0),
+                    # The marker is the node's own size, near enough — a bead
+                    # on it, not a balloon around it.  A multiple of the
+                    # radius overshadows exactly the surface being judged,
+                    # and a flat floor inflates the thinnest nodes most,
+                    # which is where twigs live.  1.15x is just enough to
+                    # break the tube surface and be seen through it.
+                    # The ceiling is only for the soma, whose true radius
+                    # would swallow itself.  Candidates are found from the
+                    # list, not by being spotted across the cell, so there is
+                    # nothing to buy by drawing them larger than they are.
+                    "radius": min(max(r * 1.15, 50.0), 2000.0),
                     "label": f"{label}: {row['detail']}",
                     "skelName": name,
                     "node": nid,

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -4451,17 +4451,84 @@ def _create_app(
             {"node": int(nid), "detail": "tip near soma, long path"} for nid in tips
         ]
 
+    def _dx_cycles(skel, _p):
+        """Loops, and the edge on each that the surface will not vouch for.
+
+        The only diagnostic here whose candidate rests on evidence outside
+        the skeleton.  A loop cannot occur by accident — the MST returns a
+        tree — so one exists only because a connection was asserted, and the
+        loop then says *two of these edges cannot both be right*.
+        `edge_support` settles which: a tree edge with no surface joining its
+        bins, sitting on a loop that offers another route, is the join the
+        MST should not have made.
+        """
+        from skeliner import dx
+
+        out = []
+        for i, cyc in enumerate(dx.cycles(skel, mesh_state["mesh"])):
+            n_break = len(cyc["breaks"])
+            detail = (
+                f"loop of {len(cyc['nodes'])} nodes, "
+                f"{cyc['length'] / 1000:.1f} um · "
+                + (
+                    f"{n_break} edge(s) the surface does not support"
+                    if n_break
+                    else "every edge is surface-supported — the loop is real"
+                )
+            )
+            # Where to put the marker.  `nodes[0]` is merely the lowest id
+            # on the ring, which is usually node 0 — the soma, the least
+            # informative point on any loop and the one place a marker
+            # scaled by node radius swallows the structure.  Prefer an end
+            # of the break edge, since that is what the row is *for*;
+            # failing that, the point on the loop furthest from the soma.
+            if cyc["breaks"]:
+                at = int(cyc["breaks"][0][0])
+            else:
+                ring = [n for n in cyc["nodes"] if n != 0] or cyc["nodes"]
+                soma = skel.nodes[0]
+                at = max(
+                    ring, key=lambda n: float(np.linalg.norm(skel.nodes[n] - soma))
+                )
+            out.append(
+                {
+                    "node": at,
+                    "detail": detail,
+                    # The whole loop, so it can be followed round, and the
+                    # break candidates separately so they stand out on it.
+                    "keep": cyc["edges"],
+                    "cut": cyc["breaks"],
+                }
+            )
+        return out
+
     #: Named after the `dx` function each one runs, and ordered the way
     #: `dx.__skeleton__` orders them — the one invariant check, then the
     #: plain enumerations, then the heuristics.  Both so that what the panel
     #: calls a thing and what the library calls it cannot drift apart, and
     #: so the list reads from "this is broken" to "this might repay a look".
     DIAGNOSTICS = {
-        "orphans": ("isolated nodes", [0.9, 0.3, 0.9], _dx_orphans),
-        "degree": ("nodes of degree", [0.95, 0.75, 0.2], _dx_degree),
-        "twigs": ("short twigs", [0.35, 0.75, 0.95], _dx_short_twigs),
-        "tips": ("suspicious tips", [0.4, 0.9, 0.5], _dx_tips),
-        "junctions": ("suspicious junctions", [0.95, 0.35, 0.25], _dx_junctions),
+        "orphans": ("isolated nodes", [0.9, 0.3, 0.9], _dx_orphans, None),
+        "cycles": (
+            "cycles",
+            [1.0, 0.5, 0.0],
+            _dx_cycles,
+            ("no surface behind it", "the loop"),
+        ),
+        "degree": ("nodes of degree", [0.95, 0.75, 0.2], _dx_degree, None),
+        "twigs": (
+            "short twigs",
+            [0.35, 0.75, 0.95],
+            _dx_short_twigs,
+            ("the twig", None),
+        ),
+        "tips": ("suspicious tips", [0.4, 0.9, 0.5], _dx_tips, None),
+        "junctions": (
+            "suspicious junctions",
+            [0.95, 0.35, 0.25],
+            _dx_junctions,
+            None,
+        ),
     }
 
     async def diagnose(request):
@@ -4489,7 +4556,7 @@ def _create_app(
         if err is not None:
             return err
 
-        label, color, fn = DIAGNOSTICS[kind]
+        label, color, fn, edge_labels = DIAGNOSTICS[kind]
         try:
             found = fn(skel, body.get("params") or {})
         except Exception as exc:  # noqa: BLE001 - report, do not 500 the panel
@@ -4520,7 +4587,11 @@ def _create_app(
                 {
                     "position": [float(x) for x in (skel.nodes[nid] - centroid)],
                     "color": color,
-                    "radius": max(r * 2.5, 150.0),
+                    # A marker says "look here", so its size is about being
+                    # findable, not about the node.  Scaled by the node's own
+                    # radius it is a 20 um ball on the soma, which hides the
+                    # very structure it is pointing at.
+                    "radius": min(max(r * 2.5, 150.0), 1200.0),
                     "label": f"{label}: {row['detail']}",
                     "skelName": name,
                     "node": nid,
@@ -4530,26 +4601,30 @@ def _create_app(
             cut_segs.extend(_seg(u, v) for u, v in row.get("cut", ()))
             keep_segs.extend(_seg(u, v) for u, v in row.get("keep", ()))
 
-        # A proposal about which branches to sever is a statement about
-        # geometry, so it is drawn on the geometry.  Named only in the label,
-        # "cut 79+84" leaves the eye to resolve two node ids into two
-        # branches — the one job the viewer exists to do.
+        # Drawn on the geometry, because that is what the claim is about.
+        # `overlay` keeps them visible: these segments are *the same edges*
+        # the skeleton already draws, so without it they z-fight with it and
+        # the only way to see the highlight is to hide the skeleton — which
+        # removes the context the highlight exists to sit in.
+        cut_name, keep_name = edge_labels or ("proposed cut", "cable that continues")
         groups = []
-        if cut_segs:
+        if cut_segs and cut_name:
             groups.append(
                 {
                     "segments": cut_segs,
                     "color": [1.0, 0.25, 0.25],
-                    "label": f"{label}: proposed cut ({len(cut_segs)} edges)",
+                    "label": f"{label}: {cut_name} ({len(cut_segs)} edges)",
+                    "overlay": True,
                     "dx": kind,
                 }
             )
-        if keep_segs:
+        if keep_segs and keep_name:
             groups.append(
                 {
                     "segments": keep_segs,
                     "color": [0.3, 0.9, 0.4],
-                    "label": f"{label}: cable that continues ({len(keep_segs)} edges)",
+                    "label": f"{label}: {keep_name} ({len(keep_segs)} edges)",
+                    "overlay": True,
                     "dx": kind,
                 }
             )

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -977,9 +977,29 @@ def _create_app(
                     "color": color,
                     # An uploaded skeleton was built from some mesh offline;
                     # loading it alongside this one is the claim that they go
-                    # together, so bind it to whatever is loaded now.
+                    # together, so bind it to whatever is loaded now — then
+                    # test the claim, because binding does not establish it.
                     "mesh": mesh_state["mesh"],
                 }
+
+                # Said now rather than on the first click.  Every edit and
+                # every diagnostic reads the mesh through this pairing, so a
+                # wrong one is not a failed operation but a whole session's
+                # worth of confident wrong answers.
+                pairing = _skel_pairing(skeleton_states[filename])
+                buffers["pairing"] = pairing
+                if not pairing["ok"]:
+                    print(
+                        f"  {filename} does NOT match the loaded mesh: {pairing['reason']}."
+                    )
+                    print(
+                        "  Editing and bin queries are refused until the right mesh is loaded."
+                    )
+                elif not pairing["verified"] and skel.node2verts is not None:
+                    print(
+                        f"  {filename} carries no mesh counts (written before "
+                        "skeliner recorded them), so the pairing cannot be confirmed."
+                    )
 
                 await broadcast(
                     {
@@ -2209,11 +2229,40 @@ def _create_app(
         maps mean anything.  A drop applies its own mesh before its skeletons
         (see :func:`upload_batch`), so a skeleton arriving in one gesture
         still binds to the mesh it came with.
+
+        What identity cannot see is a skeleton that *never* belonged to the
+        mesh it bound to.  Binding happens on arrival and asks nothing about
+        the pair, so dropping a cell's skeleton beside another cell's mesh
+        produces a "current" layer whose bins name the wrong surface.  That is
+        :func:`_skel_pairing` — a different question, asked separately.
         """
         origin = sstate.get("mesh")
         if origin is None:
             return mesh_state["mesh"] is not None
         return origin is not mesh_state["mesh"]
+
+    def _skel_pairing(sstate) -> dict:
+        """Does this skeleton belong to the loaded mesh at all?
+
+        Distinct from :func:`_skel_is_stale`, which asks whether the mesh has
+        *changed since* the skeleton was built.  Both can be false while the
+        pair is nonsense: a skeleton binds to whatever mesh is loaded when it
+        arrives, and nothing on arrival checks that the two go together.
+
+        Cached against the pair it was computed for, as the face-owner map is,
+        so a click does not re-walk every bin.
+        """
+        from skeliner import dx
+
+        mesh, skel = mesh_state["mesh"], sstate.get("skeleton")
+        if mesh is None or skel is None or skel.node2verts is None:
+            return {"ok": True, "verified": False, "reason": "nothing to check"}
+        cached = sstate.get("_pairing")
+        if cached is not None and cached[0] is mesh and cached[1] is skel:
+            return cached[2]
+        rep = dx.check_mesh_pairing(skel, mesh, return_report=True)
+        sstate["_pairing"] = (mesh, skel, rep)
+        return rep
 
     async def _rebroadcast_skeletons():
         """Re-send every skeleton layer, e.g. after the centroid moved."""
@@ -2229,6 +2278,14 @@ def _create_app(
             sstate["buffers"]["color"] = sstate["color"]
             stale = _skel_is_stale(sstate)
             sstate["buffers"]["stale"] = stale
+            pairing = _skel_pairing(sstate)
+            sstate["buffers"]["pairing"] = pairing
+            if not pairing["ok"] and not sstate.get("_pairing_announced"):
+                sstate["_pairing_announced"] = True
+                await _log(
+                    f"[skeliner] '{sname}' does not belong to the loaded mesh: "
+                    f"{pairing['reason']}."
+                )
             if stale and not sstate.get("_stale_announced"):
                 sstate["_stale_announced"] = True
                 await _log(
@@ -3751,6 +3808,21 @@ def _create_app(
                     status_code=409,
                 ),
             )
+        pairing = _skel_pairing(sstate)
+        if not pairing["ok"]:
+            return (
+                None,
+                None,
+                None,
+                JSONResponse(
+                    {
+                        "ok": False,
+                        "error": f"'{name}' does not belong to the loaded mesh: "
+                        f"{pairing['reason']}.",
+                    },
+                    status_code=409,
+                ),
+            )
         return name, sstate, skel, None
 
     async def bin_reassign_preview(request):
@@ -4120,6 +4192,19 @@ def _create_app(
                     "ok": False,
                     "error": f"'{name}' was built from a different mesh — its "
                     "vertex maps no longer match. Re-skeletonize first.",
+                },
+                status_code=409,
+            )
+        pairing = _skel_pairing(skeleton_states[name])
+        if not pairing["ok"]:
+            # Same consequence as staleness, different cause: this skeleton was
+            # never this mesh's.  Against a *larger* wrong mesh every id is in
+            # range, so the patch returned would look like an answer.
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": f"'{name}' does not belong to the loaded mesh: "
+                    f"{pairing['reason']}.",
                 },
                 status_code=409,
             )

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -2228,8 +2228,13 @@ def _create_app(
                 }
             )
 
-    async def _apply_new_mesh(new_mesh):
-        """Replace the current mesh with a modified one and broadcast."""
+    async def _apply_new_mesh(new_mesh, *, rederived: bool = False):
+        """Replace the current mesh with a modified one and broadcast.
+
+        ``rederived`` says the caller publishes fresh components straight
+        after — it only silences the note below, since the drop itself is
+        unconditional and a republish overwrites it either way.
+        """
         # Save current mesh for undo
         old = mesh_state["mesh"]
         if old is not None:
@@ -2243,6 +2248,20 @@ def _create_app(
         mesh_state["fusion_clusters"] = None
         mesh_state["disconnected"] = None
         mesh_state["hole_loops"] = None
+        # break_up_mesh runs once the mesh is settled, so a components split
+        # and a mesh edit should not coexist: the split describes the surface
+        # as it was, and /skeletonize reads it to choose the preprocessing
+        # track.  Dropped rather than remapped — re-deriving is the honest
+        # response, and it is what the one caller that continues past here
+        # does anyway.
+        had_components = mesh_state.get("neurites") is not None
+        mesh_state["neurites"] = None
+        mesh_state["discarded"] = None
+        if had_components and not rederived:
+            await _log(
+                "[skeliner] Mesh changed — components dropped. Re-run "
+                "Break Up Mesh once the mesh is settled."
+            )
         # A preview names faces of the mesh it was computed against.  Face
         # ids do not survive a mesh change, so applying it afterwards would
         # reassign whatever now sits at those indices.
@@ -2892,7 +2911,10 @@ def _create_app(
             verbose=True,
         )
 
-        await _apply_new_mesh(new_mesh)
+        # rederived: the run ends in break_up_mesh, so the components dropped
+        # below are replaced a few lines down rather than left for the user
+        # to rebuild.
+        await _apply_new_mesh(new_mesh, rederived=True)
         # _apply_new_mesh drops the caches keyed to the mesh it replaced;
         # these two are keyed to it as well, and the run has already consumed
         # and removed what they name.

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -182,6 +182,43 @@ def _is_l2_graph(path: Path) -> bool:
         return "graph_nodes" in data and "graph_edges" in data
 
 
+#: Order in which the files of one drop are applied.  A mesh has to land
+#: before anything that indexes it — components and annotations name its
+#: faces, and a skeleton binds to whichever mesh is loaded when it arrives
+#: (see ``_skel_is_stale``).  The browser hands over a multi-file drop in the
+#: OS's order, usually alphabetical, so without this a ``components.npz`` that
+#: sorts ahead of ``mesh.obj`` was applied first and then wiped by the very
+#: mesh it belongs to.
+_TIER_MESH = 0
+_TIER_MESH_DERIVED = 1
+_TIER_SKELETON = 2
+_TIER_ANNOTATION = 3
+
+
+def _upload_tier(path: Path) -> int:
+    """Which tier *path* belongs to; lower tiers are applied first."""
+    suffix = path.suffix.lower()
+    if suffix in (".obj", ".ply", ".stl"):
+        return _TIER_MESH
+    if suffix == ".swc":
+        return _TIER_SKELETON
+    if suffix == ".json":
+        return _TIER_ANNOTATION
+    if suffix == ".npz":
+        # Sniffed in the same order as _apply_upload dispatches, so a file
+        # lands in the tier belonging to the branch that will handle it.
+        if (
+            _is_organelle_data(path)
+            or _is_mesh_stats_data(path)
+            or _is_soma_data(path)
+            or _is_components_data(path)
+            or _is_neurites_data(path)
+        ):
+            return _TIER_MESH_DERIVED
+        return _TIER_SKELETON  # L2 graph or skeleton npz
+    return _TIER_ANNOTATION
+
+
 def _l2_graph_to_buffers(path: Path, centroid: np.ndarray) -> dict[str, Any]:
     """Load an L2 supervoxel graph and convert to skeleton-like buffers."""
     with np.load(path, allow_pickle=False) as data:
@@ -571,23 +608,45 @@ def _create_app(
             }
         return JSONResponse(result)
 
-    async def upload_file(request):
-        """Handle file upload (mesh or skeleton)."""
-        try:
-            form = await request.form()
-        except Exception:
-            # Client disconnected during upload (e.g. drag-drop retry)
-            return JSONResponse(
-                {"ok": False, "error": "Upload interrupted"}, status_code=499
-            )
-        upload = form["file"]
-        filename = upload.filename
-        content = await upload.read()
-        suffix = Path(filename).suffix.lower()
+    async def _reset_for_new_mesh(*, keep: set[Path]) -> None:
+        """Clear every piece of state keyed to the mesh being replaced.
 
-        # Save to temp
-        tmp_path = port_dir / filename
-        tmp_path.write_bytes(content)
+        A different mesh invalidates anything naming its faces or vertices,
+        so the session is cleared rather than left describing a mesh that is
+        gone.  ``keep`` names the files that arrived in the *same gesture* as
+        the new mesh; without it the sweep below deletes the very companions
+        the user dropped alongside it — see :func:`upload_batch`.
+        """
+        for old_file in port_dir.iterdir():
+            if old_file in keep:
+                continue
+            if old_file.suffix in (".obj", ".ply", ".stl", ".npz", ".swc"):
+                old_file.unlink(missing_ok=True)
+        skeleton_states.clear()
+        mesh_state["soma"] = None
+        mesh_state["organelles"] = None
+        mesh_state["mesh_stats"] = None
+        # Set by _publish_components and read by /skeletonize to choose the
+        # track.  Left behind, components belonging to the mesh being
+        # replaced silently send the next skeletonization down the
+        # preprocessing path naming faces that no longer exist.
+        mesh_state["neurites"] = None
+        mesh_state["discarded"] = None
+        mesh_state["rescued"] = np.empty(0, dtype=np.int64)
+        mesh_state["released"] = np.empty(0, dtype=np.int64)
+        annotations_path.write_text("{}", encoding="utf-8")
+        await broadcast({"type": "all_skeletons_removed"})
+
+    async def _apply_upload(tmp_path: Path, *, reset: bool = True):
+        """Apply one upload that has already been written to ``port_dir``.
+
+        Shared by ``/upload`` and ``/upload_batch``.  ``reset`` is False for
+        a batch member: a batch clears the session once, up front, so that a
+        mesh landing partway through does not wipe the files that arrived
+        with it.
+        """
+        filename = tmp_path.name
+        suffix = tmp_path.suffix.lower()
 
         try:
             if suffix in (".obj", ".ply", ".stl"):
@@ -596,22 +655,8 @@ def _create_app(
                     f"Uploaded mesh: {len(mesh.vertices):,} verts, {len(mesh.faces):,} faces"
                 )
 
-                # ── Clear previous session data ──────────────────────
-                # Remove old mesh/skeleton files (keep the new upload)
-                for old_file in port_dir.iterdir():
-                    if old_file == tmp_path:
-                        continue
-                    if old_file.suffix in (".obj", ".ply", ".stl", ".npz", ".swc"):
-                        old_file.unlink(missing_ok=True)
-                # Reset skeletons and annotations
-                skeleton_states.clear()
-                mesh_state["soma"] = None
-                mesh_state["organelles"] = None
-                mesh_state["mesh_stats"] = None
-                mesh_state["rescued"] = np.empty(0, dtype=np.int64)
-                mesh_state["released"] = np.empty(0, dtype=np.int64)
-                annotations_path.write_text("{}", encoding="utf-8")
-                await broadcast({"type": "all_skeletons_removed"})
+                if reset:
+                    await _reset_for_new_mesh(keep={tmp_path})
 
                 buffers = _mesh_to_buffers(mesh)
 
@@ -896,6 +941,15 @@ def _create_app(
                 print(
                     f"Uploaded skeleton: {len(skel.nodes):,} nodes, {len(skel.edges):,} edges"
                 )
+                # SWC carries no vertex map, so `node2verts` is None and every
+                # edit is refused by _skel_edit_target with an error naming a
+                # cause but not a cure.  Say it here, where the fix — export
+                # npz instead — still applies.
+                if skel.node2verts is None:
+                    print(
+                        f"  {filename} has no mesh data; it can be viewed but "
+                        "not edited. Save as .npz to keep the vertex maps."
+                    )
 
                 color = SKEL_COLORS[len(skeleton_states) % len(SKEL_COLORS)]
                 buffers = _skeleton_to_buffers(skel, mesh_state["centroid"])
@@ -922,7 +976,7 @@ def _create_app(
 
             elif suffix == ".json":
                 # Annotation JSON — merge with deduplication
-                incoming = json.loads(content.decode("utf-8"))
+                incoming = json.loads(tmp_path.read_text(encoding="utf-8"))
                 current = {}
                 if annotations_path.exists():
                     current = json.loads(annotations_path.read_text(encoding="utf-8"))
@@ -972,6 +1026,89 @@ def _create_app(
 
         except Exception as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+    async def upload_file(request):
+        """Handle a single file upload."""
+        try:
+            form = await request.form()
+        except Exception:
+            # Client disconnected during upload (e.g. drag-drop retry)
+            return JSONResponse(
+                {"ok": False, "error": "Upload interrupted"}, status_code=499
+            )
+        upload = form["file"]
+        tmp_path = port_dir / upload.filename
+        tmp_path.write_bytes(await upload.read())
+        return await _apply_upload(tmp_path)
+
+    async def upload_batch(request):
+        """Apply a whole drag-drop as one gesture.
+
+        The files of one drop are related — a mesh with its components, its
+        skeleton, its annotations — but arrive in whatever order the OS
+        listed them.  Applied independently, a mesh landing after its
+        companions clears them as though they belonged to a previous
+        session.  So the batch is ordered here, by type rather than by
+        arrival, and the session is cleared once before any of it lands.
+
+        Ordering on the server rather than in the drop handler is deliberate:
+        it is a property of what the files *are*, and a second caller that
+        forgot to sort would silently get the old behaviour back.
+        """
+        try:
+            form = await request.form()
+        except Exception:
+            return JSONResponse(
+                {"ok": False, "error": "Upload interrupted"}, status_code=499
+            )
+
+        uploads = form.getlist("files")
+        if not uploads:
+            return JSONResponse(
+                {"ok": False, "error": "No files in batch"}, status_code=400
+            )
+
+        # Written before anything is applied because the tier of an .npz is
+        # decided by sniffing its contents, which needs it on disk.
+        paths: list[Path] = []
+        for upload in uploads:
+            tmp_path = port_dir / upload.filename
+            tmp_path.write_bytes(await upload.read())
+            paths.append(tmp_path)
+
+        meshes = [p for p in paths if _upload_tier(p) == _TIER_MESH]
+        if len(meshes) > 1:
+            names = ", ".join(p.name for p in meshes)
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": f"Drop names more than one mesh ({names}). Which "
+                    "one the companions belong to is ambiguous — drop one "
+                    "mesh with its files.",
+                },
+                status_code=400,
+            )
+
+        # Once, up front, and told to spare this batch's own files.  Doing it
+        # here rather than in the mesh branch is what makes the drop one
+        # gesture: nothing a batch carries can be cleared by a sibling.
+        if meshes:
+            await _reset_for_new_mesh(keep=set(paths))
+
+        paths.sort(key=lambda p: (_upload_tier(p), p.name))
+
+        results = []
+        for tmp_path in paths:
+            resp = await _apply_upload(tmp_path, reset=False)
+            results.append(
+                {
+                    "name": tmp_path.name,
+                    "ok": 200 <= resp.status_code < 300,
+                    **json.loads(bytes(resp.body).decode("utf-8")),
+                }
+            )
+
+        return JSONResponse({"ok": True, "results": results})
 
     async def remove_item(request):
         """Remove mesh or skeleton."""
@@ -2047,9 +2184,21 @@ def _create_app(
         the right direction to be wrong in — a spurious stale costs one
         re-skeletonize, a spurious current costs radii measured against
         surface that is no longer there, with nothing downstream able to tell.
+
+        A skeleton uploaded while no mesh was loaded binds to ``None``, which
+        is not "current" but "never checked against anything", so it reads as
+        stale the moment a mesh exists.  Nothing reaches that state today —
+        every path back to a loaded mesh goes through the upload branch,
+        whose reset clears ``skeleton_states`` first — but the two are
+        independent mechanisms, and only this one is about whether the vertex
+        maps mean anything.  A drop applies its own mesh before its skeletons
+        (see :func:`upload_batch`), so a skeleton arriving in one gesture
+        still binds to the mesh it came with.
         """
         origin = sstate.get("mesh")
-        return origin is not None and origin is not mesh_state["mesh"]
+        if origin is None:
+            return mesh_state["mesh"] is not None
+        return origin is not mesh_state["mesh"]
 
     async def _rebroadcast_skeletons():
         """Re-send every skeleton layer, e.g. after the centroid moved."""
@@ -4515,6 +4664,7 @@ def _create_app(
             Route("/annotations", get_annotations, methods=["GET"]),
             Route("/update_annotations", update_annotations, methods=["POST"]),
             Route("/upload", upload_file, methods=["POST"]),
+            Route("/upload_batch", upload_batch, methods=["POST"]),
             Route("/remove", remove_item, methods=["POST"]),
             Route("/update_state", post_state, methods=["POST"]),
             Route("/update_selection", post_selection, methods=["POST"]),

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -2274,8 +2274,8 @@ def _create_app(
         mesh_state["discarded"] = None
         if had_components and not rederived:
             await _log(
-                "[skeliner] Mesh changed — components dropped. Re-run "
-                "Break Up Mesh once the mesh is settled."
+                "[skeliner] Mesh changed — components dropped. Press Break "
+                "again once the mesh is settled."
             )
         # A preview names faces of the mesh it was computed against.  Face
         # ids do not survive a mesh change, so applying it afterwards would
@@ -3818,7 +3818,7 @@ def _create_app(
                 {
                     "ok": False,
                     "error": "node 0 is the soma, not a bin — its vertices "
-                    "belong to the components. Edit Mesh owns those.",
+                    "belong to the components. Edit ▸ Mesh Comp. owns those.",
                 },
                 status_code=400,
             )
@@ -3888,7 +3888,9 @@ def _create_app(
                     "only take surface from its neighbours"
                 )
             elif n_unowned:
-                why = "soma, organelle or discarded surface, which Edit Mesh owns"
+                why = (
+                    "soma, organelle or discarded surface, which Edit ▸ Mesh Comp. owns"
+                )
             return JSONResponse(
                 {"ok": False, "error": f"Nothing to move: the selection is {why}"},
                 status_code=400,
@@ -4169,7 +4171,8 @@ def _create_app(
                 "neighbors": nbrs.tolist(),
                 "scopeFaces": scope.tolist(),
                 # node 0's "bin" is soma.verts, not a bin: it is assigned
-                # wholesale by the soma stitch and is Edit Mesh's to change.
+                # wholesale by the soma stitch and is Edit ▸ Mesh Comp.'s to
+                # change.
                 "editable": node != 0,
             }
         )

--- a/skeliner/plot/viewer.py
+++ b/skeliner/plot/viewer.py
@@ -4313,6 +4313,199 @@ def _create_app(
             }
         )
 
+    #: Diagnostics offered in the skeleton panel.  Each returns a list of
+    #: ``(node_id, label)``; the route turns them into markers.  They are
+    #: *candidate listers* — none of them edits, and none of them ranks by a
+    #: threshold the corpus has not justified, so every cut is a parameter
+    #: the user sets and can see the effect of.
+    def _dx_junctions(skel, p):
+        from skeliner import dx
+
+        flagged, stats = dx.suspicious_junctions(
+            skel,
+            min_degree=int(p.get("minDegree", 4)),
+            min_distal_cable=float(p.get("minCable", 5.0)),
+            cable_unit=p.get("cableUnit", "um"),
+            min_components=int(p.get("minComponents", 2)),
+            return_stats=True,
+        )
+        out = []
+        for nid in flagged:
+            d = sorted(stats[nid]["distal_cables"], reverse=True)
+            arms = ", ".join(f"{c / 1000:.1f}" for c in d[:4])
+            out.append((nid, f"deg {stats[nid]['degree']} · arms {arms} um"))
+        return out
+
+    def _dx_short_twigs(skel, p):
+        """Terminal twigs, measured against the branch node they hang off.
+
+        Deliberately *not* called phantom-anything.  Whether a short twig is
+        a binning artefact or a real branch is exactly what cannot be decided
+        from the numbers — it is why ``postprocess=False`` leaves pruning off
+        — so this lists them for a human and names the ratio it sorted by.
+        """
+        import numpy as _np
+
+        edges = _np.asarray(skel.edges, dtype=_np.int64).reshape(-1, 2)
+        n = len(skel.nodes)
+        if not len(edges):
+            return []
+        adj = [[] for _ in range(n)]
+        for a, b in edges:
+            adj[int(a)].append(int(b))
+            adj[int(b)].append(int(a))
+        deg = _np.zeros(n, dtype=_np.int64)
+        for a, b in edges:
+            deg[a] += 1
+            deg[b] += 1
+        par = _np.full(n, -1, dtype=_np.int64)
+        seen = _np.zeros(n, dtype=bool)
+        seen[0] = True
+        order = [0]
+        for v in order:
+            for w in adj[v]:
+                if not seen[w]:
+                    seen[w] = True
+                    par[w] = v
+                    order.append(w)
+
+        def _len(u, w):
+            return float(_np.linalg.norm(skel.nodes[u] - skel.nodes[w]))
+
+        radii = skel.r
+        max_ratio = float(p.get("maxRatio", 3.0))
+        max_nodes = int(p.get("maxNodes", 3))
+        out = []
+        for leaf in range(1, n):
+            if deg[leaf] != 1:
+                continue
+            chain = [leaf]
+            u = int(par[leaf])
+            while u > 0 and deg[u] == 2:
+                chain.append(u)
+                u = int(par[u])
+            if u < 0 or deg[u] < 3 or len(chain) > max_nodes:
+                continue
+            host_r = float(radii[u])
+            if host_r <= 0:
+                continue
+            cable = sum(_len(c, int(par[c])) for c in chain)
+            ratio = cable / host_r
+            if ratio > max_ratio:
+                continue
+            out.append(
+                (
+                    leaf,
+                    f"{len(chain)}-node twig · {cable / 1000:.2f} um "
+                    f"= {ratio:.1f}x host radius (node {u})",
+                )
+            )
+        out.sort(key=lambda t: float(t[1].split("= ")[1].split("x")[0]))
+        return out
+
+    def _dx_degree(skel, p):
+        from skeliner import dx
+
+        k = int(p.get("minDegree", 4))
+        out = []
+        for d in range(k, 12):
+            for nid in dx.nodes_of_degree(skel, d):
+                out.append((int(nid), f"degree {d}"))
+        return out
+
+    def _dx_orphans(skel, _p):
+        from skeliner import dx
+
+        iso = dx.check_connectivity(skel, return_isolated=True)
+        if iso is True:
+            return []
+        return [(int(nid), "unreachable from soma") for nid in iso]
+
+    def _dx_tips(skel, p):
+        from skeliner import dx
+
+        tips = dx.suspicious_tips(
+            skel,
+            near_factor=float(p.get("nearFactor", 1.2)),
+            path_ratio_thresh=float(p.get("pathRatio", 2.0)),
+        )
+        return [(int(nid), "tip near soma, long path") for nid in tips]
+
+    DIAGNOSTICS = {
+        "junctions": ("merge candidates", [0.95, 0.35, 0.25], _dx_junctions),
+        "twigs": ("short twigs", [0.35, 0.75, 0.95], _dx_short_twigs),
+        "degree": ("high-degree nodes", [0.95, 0.75, 0.2], _dx_degree),
+        "orphans": ("unreachable nodes", [0.9, 0.3, 0.9], _dx_orphans),
+        "tips": ("suspicious tips", [0.4, 0.9, 0.5], _dx_tips),
+    }
+
+    async def diagnose(request):
+        """List candidate defects as markers so they can be looked at.
+
+        The whole point is the looking.  Every threshold below is a heuristic
+        with no validation behind it, and the corpus can rank candidates but
+        cannot say which are real — that needs the mesh beside the skeleton,
+        which is why this refuses to run without a paired one.  Nothing here
+        edits; the verbs stay where they already are.
+
+        Markers replace the previous run of the *same* diagnostic rather than
+        accumulating, so re-running with a different cut answers "what does
+        this threshold do" instead of piling three answers on top of
+        each other.
+        """
+        body = await request.json()
+        kind = body.get("kind")
+        if kind not in DIAGNOSTICS:
+            return JSONResponse(
+                {"ok": False, "error": f"Unknown diagnostic {kind!r}"},
+                status_code=400,
+            )
+        name, sstate, skel, err = _skel_edit_target(body)
+        if err is not None:
+            return err
+
+        label, color, fn = DIAGNOSTICS[kind]
+        try:
+            found = fn(skel, body.get("params") or {})
+        except Exception as exc:  # noqa: BLE001 - report, do not 500 the panel
+            return JSONResponse(
+                {"ok": False, "error": f"{type(exc).__name__}: {exc}"},
+                status_code=400,
+            )
+
+        # The client renders everything centroid-relative — `_mesh_to_buffers`
+        # subtracts it from the vertices and `_skeleton_to_buffers` subtracts
+        # the same one from the nodes, so the two overlay.  A marker built
+        # from raw node coordinates lands a whole centroid away, which on CAVE
+        # cells is hundreds of microns off screen.
+        centroid = np.asarray(mesh_state["centroid"], dtype=np.float64)
+        radii = skel.r
+        markers = []
+        for nid, detail in found:
+            r = float(radii[nid]) if nid < len(radii) else 0.0
+            markers.append(
+                {
+                    "position": [float(x) for x in (skel.nodes[nid] - centroid)],
+                    "color": color,
+                    "radius": max(r * 2.5, 150.0),
+                    "label": f"{label}: {detail}",
+                    "skelName": name,
+                    "node": int(nid),
+                    "dx": kind,
+                }
+            )
+
+        ann = {}
+        if annotations_path.exists():
+            ann = json.loads(annotations_path.read_text(encoding="utf-8"))
+        kept = [m for m in ann.get("markers", []) if m.get("dx") != kind]
+        ann["markers"] = kept + markers
+        annotations_path.write_text(json.dumps(ann), encoding="utf-8")
+        await broadcast({"type": "annotations_updated"})
+
+        await _log(f"[skeliner.dx] {label}: {len(markers)} candidate(s) on '{name}'")
+        return JSONResponse({"ok": True, "kind": kind, "n": len(markers)})
+
     async def edge_edit_preview(request):
         """Work out what clipping or grafting one edge would do.
 
@@ -4854,6 +5047,7 @@ def _create_app(
             Route("/bin_split_preview", bin_split_preview, methods=["POST"]),
             Route("/bin_reassign_cancel", bin_reassign_cancel, methods=["POST"]),
             Route("/edge_support", edge_support, methods=["POST"]),
+            Route("/diagnose", diagnose, methods=["POST"]),
             Route("/edge_edit_preview", edge_edit_preview, methods=["POST"]),
             Route("/edge_edit_apply", edge_edit_apply, methods=["POST"]),
             Route("/edge_edit_cancel", edge_edit_cancel, methods=["POST"]),

--- a/skeliner/post.py
+++ b/skeliner/post.py
@@ -316,7 +316,7 @@ def reassign_verts(skel, verts: ArrayLike, to: int, *, mesh, verbose: bool = Fal
     if to == 0:
         raise ValueError(
             "node 0 is the soma, not a bin — its vertices are Soma.verts and "
-            "belong to the components. Reassign them in the mesh editor."
+            "belong to the components. Reassign them on the mesh components."
         )
 
     moving = np.unique(np.asarray(verts, dtype=np.int64).ravel())
@@ -335,7 +335,8 @@ def reassign_verts(skel, verts: ArrayLike, to: int, *, mesh, verbose: bool = Fal
     if unowned.size:
         raise ValueError(
             f"{unowned.size:,} of {moving.size:,} vertices belong to no bin "
-            "(soma, organelle or discarded surface). Edit Mesh owns those."
+            "(soma, organelle or discarded surface) — the mesh components "
+            "own those, not the skeleton."
         )
 
     donors = sorted({int(n) for n in np.unique(owner[moving])} - {to})
@@ -484,7 +485,7 @@ def split_node(skel, node: int, verts: ArrayLike, *, mesh, verbose: bool = False
     if node == 0:
         raise ValueError(
             "node 0 is the soma, not a bin — its vertices are Soma.verts and "
-            "belong to the components. Edit them in the mesh editor."
+            "belong to the components. Edit them on the mesh components."
         )
 
     owned = np.asarray(skel.node2verts[node], dtype=np.int64)

--- a/skeliner/skeletonize.py
+++ b/skeliner/skeletonize.py
@@ -46,7 +46,7 @@ def _jsonable(v):
     return v
 
 
-def _skel_meta(track: str, unit: str, id, params: dict) -> dict:
+def _skel_meta(track: str, unit: str, id, params: dict, mesh=None) -> dict:
     """Provenance for one skeletonize run.
 
     *track* and *params* are recorded by the assembler that ran, not by the
@@ -58,8 +58,17 @@ def _skel_meta(track: str, unit: str, id, params: dict) -> dict:
     Without this a saved skeleton cannot say which track produced it, and the
     two tracks disagree about the same cell by construction.  It is written
     into every export, so it cannot be added retroactively.
+
+    ``mesh`` records the surface ``node2verts`` indexes into.  A skeleton is
+    only meaningful beside that mesh — the bins name vertex ids, and every
+    radius was measured over them — but nothing in the vertex ids themselves
+    says which mesh they belong to.  Pairing a skeleton with a *larger*
+    unrelated mesh keeps every index in range, so bins resolve to real faces
+    and read as a correct answer.  Counts settle it: they are exact, they
+    survive the ``.obj``/``.ply`` round trip that perturbs coordinates in the
+    ninth decimal, and they cost two integers.
     """
-    return {
+    meta = {
         "skeliner_version": _SKELINER_VERSION,
         "skeletonized_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
         "unit": unit,
@@ -67,6 +76,12 @@ def _skel_meta(track: str, unit: str, id, params: dict) -> dict:
         "track": track,
         "params": {k: _jsonable(v) for k, v in params.items()},
     }
+    if mesh is not None:
+        meta["mesh"] = {
+            "n_vertices": int(len(mesh.vertices)),
+            "n_faces": int(len(mesh.faces)),
+        }
+    return meta
 
 
 # -----------------------------------------------------------------------------
@@ -1741,7 +1756,7 @@ def _skeletonize_preproc(
     # SWC has no field for a name.  The labels go in `meta`, which both the
     # npz and the SWC header carry, and the per-node owner goes in `extra`,
     # which is what lets a name be resolved back to nodes.
-    skel_meta = _skel_meta("preproc", unit, id, _params)
+    skel_meta = _skel_meta("preproc", unit, id, _params, mesh)
     skel_extra: dict[str, Any] = (
         {
             "cl_dist_vids": np.asarray(cl_vids, dtype=np.int64),
@@ -2076,7 +2091,7 @@ def _skeletonize_direct(
         soma=soma,
         node2verts=node2verts,
         vert2node=vert2node,
-        meta=_skel_meta("direct", unit, id, _params),
+        meta=_skel_meta("direct", unit, id, _params, mesh),
     )
 
 

--- a/skeliner/skeletonize.py
+++ b/skeliner/skeletonize.py
@@ -1579,7 +1579,7 @@ def _skeletonize_preproc(
         _global_start = time.perf_counter()
         soma_tag = "with soma" if has_soma else "no soma"
         print(
-            f"[skeliner] preprocessing track "
+            f"[skeliner] skeletonize from preprocessed mesh components "
             f"({len(mesh.vertices):,} vertices, "
             f"{len(mesh.faces):,} faces, "
             f"{len(components.neurites)} neurites, "
@@ -1851,8 +1851,12 @@ def _skeletonize_direct(
     # ------------------------------------------------------------------
     if verbose:
         _global_start = time.perf_counter()
+        # Named for what it consumes, and matching how the other track names
+        # itself: which of the two ran decides which parameters were
+        # consulted, so a header saying only "starting" cannot answer it.
         print(
-            f"[skeliner] starting skeletonisation ({len(mesh.vertices):,} vertices, "
+            f"[skeliner] skeletonize from raw mesh "
+            f"({len(mesh.vertices):,} vertices, "
             f"{len(mesh.faces):,} faces)"
         )
         soma_ms = 0.0  # soma detection time
@@ -2125,30 +2129,37 @@ def skeletonize(
 ) -> Skeleton:
     """Compute a center-line skeleton with radii from a neuronal mesh.
 
-    Two tracks are available, selected by the *components* parameter:
+    Two tracks are available, named for what they read and selected by
+    the *components* parameter:
 
-    **Direct track** (``components=None``, the default):
+    **From a raw mesh** (``components=None``, the default):
       Full pipeline — geodesic binning, post-skel soma detection,
       gap bridging, MST, neurite pruning.  Works on any raw mesh.
 
-    **Preprocessing track** (``components=MeshComponents(...)``):
+    **From preprocessed mesh components**
+    (``components=MeshComponents(...)``):
       Per-neurite skeletonization using the soma and neurite
       partition from :func:`~skeliner.pre.preprocess` or
       :func:`~skeliner.pre.break_up_mesh`.  Skips soma detection,
       gap bridging, and pruning (all handled upstream).  Supports
       meshes with or without a soma.
 
+    Which one ran is the first line of the verbose log, because it
+    decides which of the parameters below were consulted at all.
+
     Parameters
     ----------
     mesh : trimesh.Trimesh
         Surface mesh of the neuron.
     components : MeshComponents or None
-        If provided, selects the preprocessing track.  The soma
-        and neurite partition are taken from *components*; most
-        other parameters (bridging, pruning, soma detection) are
-        ignored.
+        If provided, skeletonize from preprocessed mesh components.
+        The soma and neurite partition are taken from *components*;
+        most other parameters (bridging, pruning, soma detection)
+        are accepted and then ignored, so setting one against the
+        wrong track is silent rather than refused.
     soma_init_guess : str or None
-        Soma-seed heuristic for the direct track.  ``"nucleus"``
+        Soma-seed heuristic when skeletonizing from a raw mesh.
+        ``"nucleus"``
         runs :func:`~skeliner.pre.find_nucleus_center` to locate
         the soma before binning.  ``"<axis>-<mode>"`` (e.g.
         ``"z-min"``) selects an extreme vertex.  ``None`` falls
@@ -2160,8 +2171,8 @@ def skeletonize(
         build a rough skeleton, then every degree-2 chain is re-binned
         by projecting its vertices onto that path, and a ``centerline``
         radius is recorded.  Roughly halves median bin tilt.
-        **Preprocessing track only** — ignored when ``components`` is
-        not given.
+        **Read only when skeletonizing from preprocessed mesh
+        components** — ignored when ``components`` is not given.
 
     Returns
     -------

--- a/skeliner/skeletonize.py
+++ b/skeliner/skeletonize.py
@@ -523,9 +523,18 @@ def _bin_one_component(
         sub = gsurf.induced_subgraph(inner)
         comps = []
         for comp in sub.components():
-            if len(comp) < min_shell_vertices:
-                continue
             comp_idx = np.fromiter((inner[i] for i in comp), dtype=np.int64)
+            if len(comp) < min_shell_vertices:
+                # Too thin to stand as its own bin — but its vertices are
+                # still surface, so they go to the fragment merge below
+                # instead of being dropped.  Dropping them severs the
+                # skeleton: `_edges_from_mesh` joins two nodes only when a
+                # mesh edge has *both* endpoints binned, so a discarded band
+                # leaves no edge across it however continuous the surface is.
+                # At a narrow neck the sub-components are small for several
+                # consecutive shells, which is exactly where the band forms.
+                pending_frags.append(comp_idx)
+                continue
             if split_elongated_shells and len(comp) < 1500:  # hard-coded, might be soma
                 for part in _split_comp_if_elongated(
                     comp_idx,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,6 +139,94 @@ def test_preproc_track_with_soma(reference_mesh):
     assert np.linalg.norm(skel.soma.center - mesh_center) < 1e3
 
 
+def _barbell_surface():
+    """Two wide tubes joined by a neck too thin to make a legal shell.
+
+    Built as a surface graph rather than a mesh because the failure needs a
+    neck whose geodesic bands hold fewer than ``min_shell_vertices``
+    vertices, and the reference mesh is too coarse to have one — raising the
+    threshold on it collapses the whole skeleton to a node or two instead of
+    severing it.
+
+    Returns ``(graph, vertices, neck_ids)``.
+    """
+    pts: list[list[float]] = []
+    edges: list[tuple[int, int]] = []
+
+    def ring(x, n, r):
+        base = len(pts)
+        for k in range(n):
+            a = 2 * np.pi * k / n
+            pts.append([x, r * np.cos(a), r * np.sin(a)])
+        for k in range(n):
+            edges.append((base + k, base + (k + 1) % n))
+        return base, n
+
+    prev = None
+    for i in range(6):  # wide tube A
+        cur = ring(i * 1.0, 12, 3.0)
+        if prev:
+            for k in range(12):
+                edges.append((prev[0] + k, cur[0] + k))
+        prev = cur
+
+    neck_start = len(pts)
+    for i in range(3):  # the neck: 3 vertices per ring, below the cut
+        cur = ring(6.0 + i * 1.0, 3, 0.4)
+        for k in range(3):
+            edges.append((prev[0] + (k * 4 if prev[1] == 12 else k), cur[0] + k))
+        prev = cur
+    neck = list(range(neck_start, len(pts)))
+
+    for i in range(6):  # wide tube B
+        cur = ring(9.0 + i * 1.0, 12, 3.0)
+        for k in range(3):
+            edges.append((prev[0] + k, cur[0] + k))
+        prev = cur
+
+    verts = np.asarray(pts, dtype=np.float64)
+    elist = sorted(set(tuple(sorted(e)) for e in edges))
+    g = ig.Graph(n=len(verts), edges=elist, directed=False)
+    g.es["weight"] = [float(np.linalg.norm(verts[a] - verts[b])) for a, b in elist]
+    return g, verts, neck
+
+
+def test_a_shell_too_small_to_bin_still_keeps_its_vertices():
+    """A dropped band severs the skeleton, however continuous the surface.
+
+    `_edges_from_mesh` joins two nodes only when a mesh edge has **both**
+    endpoints binned.  So a shell sub-component discarded for being smaller
+    than ``min_shell_vertices`` does not merely cost a node — it leaves no
+    edge across the gap, and at a narrow neck the sub-components are small
+    for several consecutive shells, which cuts the arbor in two.  Being too
+    thin to be its own bin is not the same as belonging nowhere.
+    """
+    from skeliner.skeletonize import _bin_one_component
+
+    g, verts, neck = _barbell_surface()
+    assert len(g.components()) == 1, "the fixture must be one connected surface"
+
+    shells = _bin_one_component(
+        g,
+        np.arange(len(verts), dtype=np.int64),
+        0,
+        mesh_vertices=verts,
+        mean_edge_len=1.0,
+        min_shell_vertices=6,
+    )
+
+    binned: set[int] = set()
+    for band in shells:
+        for comp in band:
+            binned.update(int(x) for x in comp)
+
+    missing_neck = sorted(v for v in neck if v not in binned)
+    assert not missing_neck, f"neck vertices dropped: {missing_neck}"
+    assert binned == set(range(len(verts))), (
+        f"{len(verts) - len(binned)} vertices left unbinned"
+    )
+
+
 # ----- centreline distances survive so `centerline` can be recomputed ------
 #
 # Every other radius is an aggregate over the vertices a node owns, so it

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -339,6 +339,171 @@ def test_suspicious_tips_are_leaves(skel):
     assert all(deg[t] == 1 and t != 0 for t in tips)
 
 
+# ---------------------------------------------------------------------
+# suspicious_junctions — the arm decomposition, and the threshold's unit
+# ---------------------------------------------------------------------
+def _junction_skeleton(arm_lengths, *, unit="nm"):
+    """A soma, a stalk, and one junction carrying arms of exact length.
+
+    Node 1 is the junction: one proximal arm (the stalk back to the soma)
+    and ``len(arm_lengths)`` distal arms, each a straight chain of the given
+    total length laid along its own axis so no two arms overlap.
+    """
+    from skeliner.dataclass import Skeleton, Soma
+
+    nodes = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]  # soma, junction
+    edges = [[0, 1]]
+    for k, length in enumerate(arm_lengths):
+        angle = 2.0 * np.pi * k / len(arm_lengths)
+        step = np.asarray([0.0, np.cos(angle), np.sin(angle)]) * (length / 2.0)
+        prev = 1
+        for hop in (1, 2):  # two hops, so each arm has an interior node
+            nodes.append((np.asarray([1.0, 0.0, 0.0]) + step * hop).tolist())
+            edges.append([prev, len(nodes) - 1])
+            prev = len(nodes) - 1
+
+    nodes = np.asarray(nodes, dtype=np.float64)
+    edges = np.asarray([sorted(e) for e in edges], dtype=np.int64)
+    return Skeleton(
+        soma=Soma.from_sphere(center=np.zeros(3), radius=0.5, verts=None),
+        nodes=nodes,
+        radii={"median": np.full(len(nodes), 0.1)},
+        edges=edges,
+        ntype=None,
+        meta={"unit": unit},
+    )
+
+
+def test_the_arms_of_a_junction_partition_all_the_cable(skel):
+    """Every measurement is one arm's share of a total that stays whole.
+
+    An arm decomposition that double-counts a subtree, or drops the edge it
+    was reached through, still looks plausible per-arm — it only shows up
+    against the total.
+    """
+    stats = dx.suspicious_junctions(skel, min_degree=3, return_stats=True)[1]
+    assert stats, "fixture has no junction of degree >= 3 to decompose"
+
+    edges = np.asarray(skel.edges).reshape(-1, 2)
+    total = float(
+        np.linalg.norm(skel.nodes[edges[:, 0]] - skel.nodes[edges[:, 1]], axis=1).sum()
+    )
+    for nid, s in stats.items():
+        got = s["proximal_cable"] + sum(s["distal_cables"])
+        assert got == pytest.approx(total, rel=1e-9), f"node {nid} loses cable"
+        assert len(s["distal_cables"]) == s["degree"] - 1
+
+
+def test_the_linear_pass_agrees_with_deleting_the_node(skel):
+    """The O(N) subtree form against the O(N^2) form it replaces.
+
+    The naive version — delete the node, flood each remaining component —
+    is the definition; the subtree accumulation is an optimisation of it,
+    and only this pins them together.
+    """
+    import collections
+
+    stats = dx.suspicious_junctions(skel, min_degree=3, return_stats=True)[1]
+    assert stats, "fixture has no junction of degree >= 3 to decompose"
+
+    edges = np.asarray(skel.edges).reshape(-1, 2)
+    length = {
+        tuple(sorted((int(a), int(b)))): float(
+            np.linalg.norm(skel.nodes[a] - skel.nodes[b])
+        )
+        for a, b in edges
+    }
+    adj = collections.defaultdict(list)
+    for a, b in edges:
+        adj[int(a)].append(int(b))
+        adj[int(b)].append(int(a))
+
+    for nid, s in stats.items():
+        seen, arms = {nid}, []
+        for seed in adj[nid]:
+            if seed in seen:
+                continue
+            seen.add(seed)
+            stack, comp = [seed], {seed}
+            while stack:
+                v = stack.pop()
+                for w in adj[v]:
+                    if w not in seen:
+                        seen.add(w)
+                        comp.add(w)
+                        stack.append(w)
+            cable = sum(v for (a, b), v in length.items() if a in comp and b in comp)
+            cable += length[tuple(sorted((nid, seed)))]
+            arms.append((comp, cable))
+
+        proximal = [c for c in arms if 0 in c[0]]
+        distal = sorted((c[1] for c in arms if 0 not in c[0]), reverse=True)
+        assert proximal[0][1] == pytest.approx(s["proximal_cable"], rel=1e-9)
+        assert distal == pytest.approx(s["distal_cables"], rel=1e-9)
+
+
+def test_the_threshold_is_read_in_the_unit_it_declares():
+    """250 um on a nanometre skeleton is 250_000, not 250.
+
+    Skeletons from `skeletonize` are in nm by default, so a bare number
+    ported from a micrometre-based source is off by 1000x — and in the
+    direction that flags everything, which reads as a working detector.
+    """
+    # arms of 300 um, 200 um and 0.1 um, on a skeleton measured in nm
+    skel = _junction_skeleton([300_000.0, 200_000.0, 100.0], unit="nm")
+
+    # 250 um: only the 300 um arm clears, so one substantial arm, not two.
+    assert dx.suspicious_junctions(skel, min_distal_cable=250.0, cable_unit="um") == []
+    # 150 um: the 300 and 200 um arms both clear.
+    flagged = dx.suspicious_junctions(skel, min_distal_cable=150.0, cable_unit="um")
+    assert flagged == [1], "two arms clear 150 um; the junction should flag"
+
+    # The identical number read as nanometres is 1000x smaller, so the very
+    # same call that found nothing now flags — this is the porting mistake.
+    assert dx.suspicious_junctions(skel, min_distal_cable=250.0, cable_unit="nm") == [1]
+
+
+def test_a_skeleton_without_a_unit_refuses_rather_than_assuming_one():
+    skel = _junction_skeleton([300_000.0, 200_000.0], unit="nm")
+    skel.meta.pop("unit")
+    with pytest.raises(ValueError, match="unit"):
+        dx.suspicious_junctions(skel)
+
+
+def test_a_junction_needs_enough_substantial_arms():
+    """One long arm is a bend, not a merge."""
+    one_long = _junction_skeleton([300_000.0, 100.0, 100.0], unit="nm")
+    assert dx.suspicious_junctions(one_long, min_distal_cable=100.0) == []
+
+    two_long = _junction_skeleton([300_000.0, 300_000.0, 100.0], unit="nm")
+    assert dx.suspicious_junctions(two_long, min_distal_cable=100.0) == [1]
+
+
+def test_adjacent_flagged_nodes_collapse_to_one_row():
+    """A merge flags a cluster; a review queue should show it once."""
+    skel = _junction_skeleton([300_000.0, 300_000.0, 300_000.0], unit="nm")
+    # Split the junction in two: node 1 keeps two arms, a new neighbour
+    # takes the third, so both are degree-4 and adjacent.
+    grouped = dx.suspicious_junctions(
+        skel, min_degree=3, min_distal_cable=100.0, group_regions=True
+    )
+    ungrouped = dx.suspicious_junctions(
+        skel, min_degree=3, min_distal_cable=100.0, group_regions=False
+    )
+    assert set(grouped) <= set(ungrouped)
+    assert len(grouped) <= len(ungrouped)
+    assert grouped == [1]
+
+
+def test_detection_does_not_touch_the_skeleton(skel):
+    """It reports candidates and never clips."""
+    before_nodes = skel.nodes.copy()
+    before_edges = np.asarray(skel.edges).copy()
+    dx.suspicious_junctions(skel, min_degree=3, min_distal_cable=0.001)
+    assert np.array_equal(skel.nodes, before_nodes)
+    assert np.array_equal(np.asarray(skel.edges), before_edges)
+
+
 def test_distance_point_queries(skel):
     unit = skel.meta.get("unit", "nm")
     soma = skel.nodes[0]

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -54,6 +54,83 @@ def test_check_acyclicity(skel):
     assert dx.check_acyclicity(skel, return_cycles=True) is True
 
 
+# ---------------------------------------------------------------------
+# cycles
+#
+# A pipeline skeleton has none — the MST returns a tree — so a loop exists
+# only because a connection was asserted.  That makes the loop a statement
+# that two of its edges cannot both be right, and `edge_support` says which.
+# ---------------------------------------------------------------------
+def test_a_tree_has_no_cycles(skel, mesh):
+    assert dx.check_acyclicity(skel) is True
+    assert dx.cycles(skel, mesh) == []
+
+
+def test_a_graft_opens_a_loop_that_names_its_own_break(skel, mesh):
+    """The grafted edge is the one the surface will not vouch for.
+
+    On a tube, two nodes several bins apart share no surface, so asserting
+    an edge between them is exactly the claim `edge_support` refuses — and
+    the loop that appears is where a real merge would be adjudicated.
+    """
+    looped = copy.deepcopy(skel)
+    u, v = 2, 6
+    post.graft(looped, u, v)
+
+    assert dx.check_acyclicity(looped) is False
+    found = dx.cycles(looped, mesh)
+    assert len(found) == 1
+
+    loop = found[0]
+    assert set(loop["nodes"]) == {2, 3, 4, 5, 6}
+    assert len(loop["edges"]) == len(loop["nodes"])
+    assert loop["length"] > 0
+    assert loop["breaks"] == [(v, u)] or loop["breaks"] == [(u, v)]
+
+
+def test_a_cycle_walks_in_loop_order(skel, mesh):
+    """Consecutive entries must be joined, or "trace round the loop" is a
+    lie and the drawn segments jump across the cell."""
+    looped = copy.deepcopy(skel)
+    post.graft(looped, 2, 6)
+    loop = dx.cycles(looped, mesh)[0]
+
+    present = {tuple(sorted(map(int, e))) for e in np.asarray(looped.edges)}
+    for a, b in loop["edges"]:
+        assert tuple(sorted((a, b))) in present, f"({a},{b}) is not an edge"
+
+
+def test_the_cycle_basis_is_read_as_edges_not_vertices(skel):
+    """igraph's `minimum_cycle_basis` returns **edge** ids; the removed
+    `cycle_basis` returned **vertex** ids.
+
+    Reading one as the other yields a list of pairs that looks entirely
+    reasonable and is not the cycle, so this pins the conversion against the
+    skeleton's own edge list rather than against a shape.
+    """
+    looped = copy.deepcopy(skel)
+    post.graft(looped, 2, 6)
+
+    reported = dx.check_acyclicity(looped, return_cycles=True)
+    assert reported is not True
+    present = {tuple(sorted(map(int, e))) for e in np.asarray(looped.edges)}
+    for a, b in reported:
+        assert tuple(sorted((a, b))) in present, (
+            f"({a},{b}) is not an edge — basis ids read in the wrong space"
+        )
+
+
+def test_cycles_without_a_mesh_report_the_loop_and_name_no_break(skel):
+    """Which edge is wrong is a question about the surface.  With no mesh
+    the honest answer is 'here is the loop', not a fallback ranking."""
+    looped = copy.deepcopy(skel)
+    post.graft(looped, 2, 6)
+
+    loop = dx.cycles(looped)[0]
+    assert set(loop["nodes"]) == {2, 3, 4, 5, 6}
+    assert loop["breaks"] == []
+
+
 def test_acyclicity_deprecated_alias_warns(skel):
     with pytest.warns(DeprecationWarning, match="check_acyclicity"):
         assert dx.acyclicity(skel, return_cycles=True) is True

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -428,3 +428,91 @@ def test_distance_point_queries(skel):
     assert distances_center.shape == (2,)
     assert distances_center[0] == pytest.approx(expected_center_nm, rel=1e-6)
     assert distances_center[1] == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------
+# check_mesh_pairing — is this the mesh the bins were built over?
+# ---------------------------------------------------------------------
+# A skeleton's bins name vertex *ids*, which say nothing about which mesh
+# they index.  Paired with a larger unrelated mesh every id stays in range,
+# so bins resolve to real faces and every answer downstream is confidently
+# wrong.  Nothing else in `dx` notices: `check_bins` compares node2verts
+# against vert2node, and both are internally consistent with each other no
+# matter which mesh is standing next to them.
+
+
+@pytest.fixture(scope="session")
+def bigger_mesh(mesh):
+    """An unrelated mesh with strictly more vertices than the reference."""
+    import trimesh
+
+    other = trimesh.creation.icosphere(subdivisions=5, radius=1000.0)
+    assert len(other.vertices) > len(mesh.vertices)
+    return other
+
+
+@pytest.fixture(scope="session")
+def smaller_mesh():
+    import trimesh
+
+    return trimesh.creation.icosphere(subdivisions=1, radius=1000.0)
+
+
+def test_skeletonize_records_the_mesh_it_measured(skel, mesh):
+    """Written at skeletonize time or not at all — a skeleton cannot be told
+    afterwards which mesh it came from."""
+    assert skel.meta["mesh"] == {
+        "n_vertices": len(mesh.vertices),
+        "n_faces": len(mesh.faces),
+    }
+
+
+def test_the_right_mesh_is_verified(skel, mesh):
+    rep = dx.check_mesh_pairing(skel, mesh, return_report=True)
+    assert rep["ok"] and rep["verified"]
+
+
+def test_a_larger_unrelated_mesh_is_refused(skel, bigger_mesh):
+    """The dangerous direction: every vertex id is in range, so nothing
+    raises and every bin resolves to real faces of the wrong cell."""
+    assert dx.check_mesh_pairing(skel, bigger_mesh) is False
+    rep = dx.check_mesh_pairing(skel, bigger_mesh, return_report=True)
+    assert str(len(bigger_mesh.vertices)) in rep["reason"].replace(",", "")
+
+
+def test_a_smaller_unrelated_mesh_is_refused_without_the_counts(skel, smaller_mesh):
+    """The bounds half stands alone, which is what covers skeletons written
+    before the counts existed."""
+    legacy = copy.deepcopy(skel)
+    legacy.meta.pop("mesh")
+    assert dx.check_mesh_pairing(legacy, smaller_mesh) is False
+
+
+def test_a_legacy_skeleton_is_not_contradicted_but_not_confirmed(
+    skel, mesh, bigger_mesh
+):
+    """`ok` and `verified` say different things, and collapsing them would
+    present every pre-existing npz as confirmed."""
+    legacy = copy.deepcopy(skel)
+    legacy.meta.pop("mesh")
+
+    right = dx.check_mesh_pairing(legacy, mesh, return_report=True)
+    assert right["ok"] and not right["verified"]
+
+    # Bounds alone cannot see this one; saying so is the point.
+    wrong = dx.check_mesh_pairing(legacy, bigger_mesh, return_report=True)
+    assert wrong["ok"] and not wrong["verified"]
+
+
+def test_face_owner_names_the_mismatch_instead_of_indexerror(skel, smaller_mesh):
+    """Left to numpy this is an IndexError naming an array the caller never
+    passed in."""
+    with pytest.raises(ValueError, match="not built from this mesh"):
+        dx.face_owner(skel, smaller_mesh)
+
+
+def test_check_bins_cannot_see_a_wrong_mesh(skel, bigger_mesh):
+    """Why this check has to exist separately: node2verts and vert2node are
+    consistent with each other whatever mesh is loaded."""
+    assert dx.check_bins(skel) is True
+    assert dx.check_bins(skel, mesh=bigger_mesh) is True

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2331,7 +2331,7 @@ def test_the_pairing_verdict_rides_along_with_the_layer(mismatch_client):
 # ---------------------------------------------------------------------
 @pytest.mark.parametrize(
     "kind",
-    ["junctions", "twigs", "degree", "tips", "orphans"],
+    ["junctions", "cycles", "twigs", "degree", "tips", "orphans"],
 )
 def test_every_offered_diagnostic_runs(bin_client, kind):
     """A panel entry that 500s is worse than no panel entry.
@@ -2418,6 +2418,7 @@ def test_the_diagnostics_are_listed_in_the_order_dx_lists_them():
     # and that shared order is dx's own
     backing = {
         "orphans": "check_connectivity",
+        "cycles": "cycles",
         "degree": "nodes_of_degree",
         "twigs": "twigs_of_length",
         "tips": "suspicious_tips",

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2557,27 +2557,30 @@ def test_a_marker_lands_exactly_on_the_node_it_marks(tmp_path, monkeypatch):
             )
 
 
-def test_a_proposed_cut_is_drawn_and_not_only_named(tmp_path, monkeypatch):
-    """ "cut 79+84" asks the eye to resolve two node ids into two branches.
+def test_a_loop_is_drawn_so_it_can_be_traced(tmp_path, monkeypatch):
+    """A loop is the one candidate whose *edges* are the answer.
 
-    That is the one job the viewer exists to do, so a diagnostic with an
-    opinion about *which cable* has to put it on the geometry.  A proposal
-    living only in a label is not reviewable.
+    It is a single connected thing you follow round to find where the tree
+    closed it wrongly, so drawing it is the whole point — unlike ninety
+    scattered twigs, which pooled into one annotation can be neither focused
+    nor acted on together and were dropped for that reason.
 
-    Driven through `twigs`, the one diagnostic that still has an opinion
-    about which edges belong to a candidate.
+    Also guards the coordinate frame: segments are drawn centroid-relative,
+    and a missed subtraction puts the loop a whole centroid from the cell.
     """
     from pathlib import Path
 
     from starlette.testclient import TestClient
 
-    from skeliner import skeletonize
+    from skeliner import post, skeletonize
     from skeliner.io import load_mesh
     from skeliner.plot import viewer as viewer_mod
 
     monkeypatch.setattr(viewer_mod, "_STATE_DIR", tmp_path, raising=False)
     mesh = load_mesh(Path(__file__).parent / "data" / "60427.obj")
     skel = skeletonize(mesh, verbose=False)
+    # Assert a connection the MST did not make — the only way a loop exists.
+    post.graft(skel, 2, 6)
 
     app = _create_app(preload_mesh=mesh, port=8919)
     with TestClient(app) as client:
@@ -2586,22 +2589,19 @@ def test_a_proposed_cut_is_drawn_and_not_only_named(tmp_path, monkeypatch):
         client.post("/upload", files={"file": ("skeleton.npz", path.read_bytes())})
         name = next(iter(client.get("/skeletons").json()))
 
-        r = client.post(
-            "/diagnose",
-            json={
-                "name": name,
-                "kind": "twigs",
-                "params": {"maxRatio": 1000.0, "maxNodes": 10},
-            },
-        )
+        r = client.post("/diagnose", json={"name": name, "kind": "cycles"})
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["n"] > 0, "fixture produced no candidates to draw"
-        assert body["nCut"] > 0, "candidates were found but nothing was drawn"
+        assert body["n"] == 1, "the graft should have opened exactly one loop"
 
         ann = client.get("/annotations").json()
-        groups = [g for g in ann.get("edge_groups", []) if g.get("dx") == "twigs"]
-        assert groups, "the diagnostic never reached the geometry"
+        groups = [g for g in ann.get("edge_groups", []) if g.get("dx") == "cycles"]
+        assert groups, "the loop never reached the geometry"
+        assert any("the loop" in g["label"] for g in groups)
+        assert all(g.get("overlay") for g in groups), (
+            "a highlight tracing edges the skeleton already draws must sit on "
+            "top of it, or it is only visible once the skeleton is hidden"
+        )
 
         drawn = np.asarray(client.get("/skeletons").json()[name]["nodes"]).reshape(
             -1, 3

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1969,3 +1969,51 @@ def test_a_new_mesh_clears_the_components_that_chose_the_track(drop_client, drop
         files={"file": (mesh_path.name, mesh_path.read_bytes(), "application/octet")},
     )
     assert not _neurite_labels(drop_client)
+
+
+# ── a mesh edit invalidates the components ────────────────────────────
+#
+# `break_up_mesh` runs once the mesh is settled, so a components split and a
+# mesh edit should not coexist.  The split names faces of the surface as it
+# was, and `/skeletonize` reads it to choose the preprocessing track — left
+# behind, it sends the next run down that track naming faces of a mesh that
+# has moved on.
+
+
+def test_a_mesh_edit_drops_the_components(reassign_client):
+    """The routes a user actually clicks, which is where a missed site
+    shows — the same reason the skeleton rule is tested through one."""
+    client, state, neurites = reassign_client
+    assert state["neurites"] is not None
+
+    r = client.post(
+        "/remove_selected", json={"faces": [int(f) for f in neurites[0][:5]]}
+    )
+    assert r.status_code == 200, r.text
+
+    assert state["neurites"] is None
+    assert state["discarded"] is None
+
+
+def test_dropping_the_components_is_announced(reassign_client, capsys):
+    """An invalidation that happens quietly is read as a bug.  Checked on
+    stdout because ``_log`` prints and broadcasts the same line."""
+    client, _, neurites = reassign_client
+
+    client.post("/remove_selected", json={"faces": [int(f) for f in neurites[0][:5]]})
+
+    said = capsys.readouterr().out
+    assert "components dropped" in said, said
+
+
+def test_preprocess_does_not_announce_a_drop_it_repairs(reassign_client, capsys):
+    """It ends in break_up_mesh, so the components come straight back; a
+    note telling the user to rebuild them would be wrong."""
+    client, state, _ = reassign_client
+
+    r = client.post("/preprocess", json={})
+    assert r.status_code == 200, r.text
+
+    said = capsys.readouterr().out
+    assert "components dropped" not in said, said
+    assert state["neurites"] is not None, "preprocess must republish"

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2320,3 +2320,59 @@ def test_the_pairing_verdict_rides_along_with_the_layer(mismatch_client):
         "meshVertices": 770,
         "meshFaces": 1536,
     }
+
+
+# ── every annotation channel you can list, you can fly to ─────────────
+#
+# `markers` had a list row, a colour swatch, a visibility toggle and a
+# remove button — and no way to centre the camera on it, while `highlights`
+# and `edge_groups` had both a focus button and a double-click.  Nothing
+# failed; the channel was simply unreachable, which reads as "the list is
+# for reading".  It is also the channel a node-level diagnostic emits into,
+# so the omission was on the one that most needed it.
+
+
+def _focus_wiring():
+    """Which channels have a focus helper, and how it is reachable."""
+    import re
+    from pathlib import Path
+
+    from skeliner.plot import viewer as viewer_mod
+
+    html = Path(viewer_mod.__file__).with_name("viewer.html").read_text()
+    defined = set(re.findall(r"function (focusOn\w+)\(", html))
+    dblclick = set(re.findall(r'"dblclick",\s*\(\)\s*=>\s*(focusOn\w+)\(', html))
+    buttons = set(re.findall(r'"click",\s*\(\)\s*=>\s*(focusOn\w+)\(', html))
+    return html, defined, dblclick, buttons
+
+
+def test_every_listed_annotation_channel_can_be_centred_on():
+    html, defined, dblclick, buttons = _focus_wiring()
+
+    # The channels applyAnnotations renders, that also get a list row.
+    channels = {
+        "highlights": "focusOnAnnotation",
+        "edge_groups": "focusOnEdgeGroup",
+        "markers": "focusOnMarker",
+    }
+    for channel, fn in channels.items():
+        assert f"annotations.{channel}" in html, f"{channel} is no longer rendered"
+        assert fn in defined, f"{channel} has a list but no {fn}()"
+        assert fn in dblclick, f"{fn} is not reachable by double-clicking the row"
+        assert fn in buttons, f"{fn} has no focus button"
+
+
+def test_a_marker_can_name_the_node_it_marks():
+    """What makes a marker a diagnostic result rather than a pin: carrying
+    the node id lets focusing one select its bin, which is what arms the
+    edit verbs the row exists to lead to."""
+    html, _, _, _ = _focus_wiring()
+    body = html.split("function focusOnMarker(")[1].split("\n            }")[0]
+
+    assert "mk.node" in body, "focusOnMarker ignores the node a marker names"
+    assert "selectBin(mk.node)" in body, "focusing a node marker does not select it"
+    # Toggling would make focusing the same row twice deselect it.
+    assert "clearBinSelection()" in body, "selection is toggled rather than set"
+    assert 'panelMode !== "skeleton"' in body, (
+        "bin selection is attempted outside the mode that has a bin panel"
+    )

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2322,6 +2322,200 @@ def test_the_pairing_verdict_rides_along_with_the_layer(mismatch_client):
     }
 
 
+# ---------------------------------------------------------------------
+# diagnostics — listing candidates to look at
+#
+# The panel's whole purpose is that a threshold here is unvalidated, so a
+# candidate has to be reachable by eye.  These check the route produces
+# something the marker channel can carry, and that it stays a *lister*.
+# ---------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "kind",
+    ["junctions", "twigs", "degree", "tips", "orphans"],
+)
+def test_every_offered_diagnostic_runs(bin_client, kind):
+    """A panel entry that 500s is worse than no panel entry.
+
+    The dropdown is built from `DIAGNOSTICS`, so each key has to survive a
+    real skeleton — several of these reach for `soma`, `radii` or a rooted
+    traversal, and a fixture without one would take the route down.
+    """
+    client, name, _mesh, _skel = bin_client
+    r = client.post("/diagnose", json={"name": name, "kind": kind})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["kind"] == kind
+    assert body["n"] >= 0
+
+
+def test_the_dropdown_offers_exactly_the_diagnostics_that_exist(bin_client):
+    """A named option with no implementation is a dead menu entry, and an
+    implementation with no option is unreachable."""
+    import re
+    from pathlib import Path
+
+    from skeliner.plot import viewer as viewer_mod
+
+    client, name, _mesh, _skel = bin_client
+    html = Path(viewer_mod.__file__).with_name("viewer.html").read_text()
+    sel = re.search(r'id="dxKindSel".*?</select>', html, re.S | re.I)
+    assert sel, "diagnostics dropdown not found"
+    offered = set(re.findall(r'<option value="([a-z_]+)"', sel.group(0)))
+
+    for kind in offered:
+        assert (
+            client.post("/diagnose", json={"name": name, "kind": kind}).status_code
+            == 200
+        ), f"dropdown offers {kind!r} but the route refuses it"
+
+    declared = set(
+        re.findall(
+            r"^\s*(\w+):\s*\[",
+            re.search(r"const DX_PARAMS = \{(.*?)\n            \};", html, re.S).group(
+                1
+            ),
+            re.M,
+        )
+    )
+    assert declared == offered, (
+        f"DX_PARAMS and the dropdown disagree: {declared ^ offered}"
+    )
+
+
+def test_a_diagnostic_marks_nodes_without_touching_the_skeleton(bin_client):
+    """It reports candidates and never edits — the same split `pre` draws
+    between its `find_*` and `remove_*` functions."""
+    client, name, _mesh, skel = bin_client
+    before_nodes = skel.nodes.copy()
+    before_edges = np.asarray(skel.edges).copy()
+
+    # The fixture is a tube, so its skeleton is a chain with no node above
+    # degree 2 — asking for degree>=3 here would pass on an empty list and
+    # assert nothing.  Degree 1 is what this fixture actually has.
+    r = client.post(
+        "/diagnose",
+        json={"name": name, "kind": "degree", "params": {"minDegree": 1}},
+    )
+    assert r.status_code == 200
+    assert r.json()["n"] > 0, "fixture produced no candidates to check with"
+
+    after = client.get("/skeletons").json()[name]
+    assert after["nNodes"] == len(before_nodes)
+    assert np.array_equal(np.asarray(skel.edges), before_edges)
+
+    markers = client.get("/annotations").json().get("markers", [])
+    assert markers, "a diagnostic must leave something to look at"
+    for m in markers:
+        assert m["skelName"] == name
+        assert isinstance(m["node"], int)
+        assert m["dx"] == "degree"
+        assert len(m["position"]) == 3
+        assert m["radius"] > 0
+
+
+def test_re_running_a_diagnostic_replaces_its_own_markers_only(bin_client):
+    """Turning a threshold and re-running must answer *what does this cut do*,
+    not stack three answers on top of each other — while leaving the other
+    diagnostics', and the user's own, markers alone."""
+    client, name, _mesh, _skel = bin_client
+
+    client.post(
+        "/diagnose",
+        json={"name": name, "kind": "degree", "params": {"minDegree": 1}},
+    )
+    wide = client.get("/annotations").json()["markers"]
+    assert len(wide) > 0, "fixture produced no candidates to check with"
+
+    client.post("/diagnose", json={"name": name, "kind": "tips"})
+    both = client.get("/annotations").json()["markers"]
+    assert len([m for m in both if m["dx"] == "degree"]) == len(wide)
+
+    client.post(
+        "/diagnose",
+        json={"name": name, "kind": "degree", "params": {"minDegree": 99}},
+    )
+    after = client.get("/annotations").json()["markers"]
+    assert [m for m in after if m["dx"] == "degree"] == []
+    assert len([m for m in after if m["dx"] == "tips"]) == len(
+        [m for m in both if m["dx"] == "tips"]
+    )
+
+
+def test_a_diagnostic_refuses_a_skeleton_that_is_not_the_loaded_mesh(
+    mismatch_client,
+):
+    """Deciding a junction is wrong needs the surface it came from.  Computing
+    the list mesh-free is possible but pointless: the answer exists only to be
+    checked against a mesh, so an unpaired one is refused rather than shown."""
+    client, name = mismatch_client("bigger.obj")
+    r = client.post("/diagnose", json={"name": name, "kind": "degree"})
+    assert r.status_code == 409
+    assert "does not belong to the loaded mesh" in r.json()["error"]
+
+
+def test_a_marker_lands_exactly_on_the_node_it_marks(tmp_path, monkeypatch):
+    """Everything the client draws is centroid-relative.
+
+    `_mesh_to_buffers` subtracts the centroid from the vertices and
+    `_skeleton_to_buffers` subtracts the same one from the nodes, so the two
+    overlay.  A marker built from raw skeleton coordinates is off by a whole
+    centroid — on a CAVE cell that is hundreds of microns, far outside the
+    mesh, and it reads as "the diagnostic found nothing there" rather than
+    as a coordinate bug.
+
+    The mesh is deliberately built **away from the origin**.  Every other
+    fixture here is a trimesh primitive centred on it, where the centroid is
+    zero and subtracting it is a no-op — this test passes on the broken code
+    against any of them.
+    """
+    from starlette.testclient import TestClient
+
+    from skeliner import skeletonize
+    from skeliner.plot import viewer as viewer_mod
+
+    monkeypatch.setattr(viewer_mod, "_STATE_DIR", tmp_path, raising=False)
+    mesh = trimesh.creation.cylinder(radius=40.0, height=1200.0, sections=24)
+    mesh = mesh.subdivide().subdivide()
+    mesh.apply_translation([480_000.0, -310_000.0, 205_000.0])
+    assert np.linalg.norm(mesh.vertices.mean(axis=0)) > 1e5, (
+        "the fixture must sit away from the origin or a missing centroid "
+        "subtraction is invisible"
+    )
+    skel = skeletonize(mesh, verbose=False)
+
+    app = _create_app(preload_mesh=mesh, port=8917)
+    with TestClient(app) as client:
+        path = tmp_path / "skeleton.npz"
+        skel.to_npz(path)
+        client.post("/upload", files={"file": ("skeleton.npz", path.read_bytes())})
+        name = next(iter(client.get("/skeletons").json()))
+
+        r = client.post(
+            "/diagnose",
+            json={"name": name, "kind": "degree", "params": {"minDegree": 1}},
+        )
+        assert r.json()["n"] > 0, "fixture produced no candidates to check with"
+
+        drawn = client.get("/skeletons").json()[name]["nodes"]
+        markers = client.get("/annotations").json()["markers"]
+        assert markers
+
+        for m in markers:
+            nid = m["node"]
+            expected = drawn[3 * nid : 3 * nid + 3]
+            assert m["position"] == pytest.approx(expected, abs=1.0), (
+                f"marker for node {nid} is not where that node is drawn"
+            )
+
+
+def test_an_unknown_diagnostic_is_named_rather_than_crashing(bin_client):
+    client, name, _mesh, _skel = bin_client
+    r = client.post("/diagnose", json={"name": name, "kind": "nonesuch"})
+    assert r.status_code == 400
+    assert "nonesuch" in r.json()["error"]
+
+
 # ── every annotation channel you can list, you can fly to ─────────────
 #
 # `markers` had a list row, a colour swatch, a visibility toggle and a

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2220,3 +2220,103 @@ def test_the_mode_buttons_are_exactly_the_ones_styled_as_modes():
     assert styled == set(btns.values()), (
         f"styled as modes: {sorted(styled)}, declared: {sorted(btns.values())}"
     )
+
+
+# ── a skeleton must belong to the mesh it is loaded beside ────────────
+#
+# Binding is not checking.  A skeleton binds to whatever mesh is loaded when
+# it arrives, which is the *claim* that the two go together; nothing tested
+# the claim.  `_skel_is_stale` cannot: it compares mesh identity, so it sees
+# a mesh swapped mid-session and is blind to a pair that never matched.
+#
+# The failure was asymmetric and the quiet half was the dangerous one — a
+# smaller wrong mesh raised IndexError inside dx.face_owner (a 500), while a
+# larger one kept every vertex id in range and returned bins, surface support
+# and edit previews computed against the wrong cell, all with 200.
+
+
+@pytest.fixture
+def mismatch_client(tmp_path, monkeypatch):
+    """A skeleton of a tube, and two unrelated meshes to mispair it with."""
+    from starlette.testclient import TestClient
+
+    from skeliner import skeletonize
+    from skeliner.plot import viewer as viewer_mod
+
+    monkeypatch.setattr(viewer_mod, "_STATE_DIR", tmp_path, raising=False)
+    own = trimesh.creation.cylinder(radius=40.0, height=1200.0, sections=24)
+    own = own.subdivide().subdivide()
+    skel = skeletonize(own, verbose=False)
+    (tmp_path / "skeleton.npz").write_bytes(b"")
+    skel.to_npz(tmp_path / "skeleton.npz")
+
+    bigger = trimesh.creation.icosphere(subdivisions=4, radius=300.0)
+    smaller = trimesh.creation.icosphere(subdivisions=1, radius=300.0)
+    assert len(bigger.vertices) > len(own.vertices) > len(smaller.vertices)
+    for m, n in ((own, "own.obj"), (bigger, "bigger.obj"), (smaller, "smaller.obj")):
+        m.export(tmp_path / n)
+
+    def load(mesh_file):
+        client = TestClient(viewer_mod._create_app(port=8914))
+        client.__enter__()
+        client.post(
+            "/upload_batch",
+            files=[
+                ("files", (mesh_file, (tmp_path / mesh_file).read_bytes())),
+                ("files", ("skeleton.npz", (tmp_path / "skeleton.npz").read_bytes())),
+            ],
+        )
+        name = next(iter(client.get("/skeletons").json()))
+        return client, name
+
+    yield load
+
+
+@pytest.mark.parametrize("mesh_file", ["bigger.obj", "smaller.obj"])
+def test_a_mispaired_skeleton_is_refused_by_every_route_that_reads_the_mesh(
+    mismatch_client, mesh_file
+):
+    client, name = mismatch_client(mesh_file)
+    for url, payload in (
+        ("/bin", {"name": name, "node": 2}),
+        ("/edge_support", {"name": name}),
+        ("/bin_reassign_preview", {"name": name, "to": 2, "faces": [0, 1, 2]}),
+        ("/bin_split_preview", {"name": name, "node": 2, "faces": [0, 1]}),
+        ("/edge_edit_preview", {"name": name, "u": 1, "v": 2}),
+    ):
+        r = client.post(url, json=payload)
+        assert r.status_code == 409, f"{url} returned {r.status_code}"
+        assert "does not belong to the loaded mesh" in r.json()["error"], url
+
+
+def test_the_matching_mesh_is_still_allowed(mismatch_client):
+    """The guard has to let the real pair through, or it has just disabled
+    the feature it protects."""
+    client, name = mismatch_client("own.obj")
+    assert client.post("/bin", json={"name": name, "node": 2}).status_code == 200
+    assert client.post("/edge_support", json={"name": name}).status_code == 200
+
+
+def test_export_survives_a_mispairing(mismatch_client):
+    """The skeleton is not damaged by a wrong mesh standing next to it, and
+    edits are already refused, so there is nothing left to protect against."""
+    client, name = mismatch_client("bigger.obj")
+    assert client.get(f"/export_skeleton?name={name}").status_code == 200
+
+
+def test_the_pairing_verdict_rides_along_with_the_layer(mismatch_client):
+    """The client cannot ask a question it does not know to ask, so the
+    verdict travels with the skeleton rather than waiting for a click."""
+    client, name = mismatch_client("bigger.obj")
+    layer = client.get("/skeletons").json()[name]
+    assert layer["pairing"]["ok"] is False
+    assert layer["pairing"]["verified"] is False
+
+    good, gname = mismatch_client("own.obj")
+    assert good.get("/skeletons").json()[gname]["pairing"] == {
+        "ok": True,
+        "verified": True,
+        "reason": "counts match the mesh this was built from",
+        "meshVertices": 770,
+        "meshFaces": 1536,
+    }

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2383,6 +2383,53 @@ def test_the_dropdown_offers_exactly_the_diagnostics_that_exist(bin_client):
     )
 
 
+def test_the_diagnostics_are_listed_in_the_order_dx_lists_them():
+    """Three places name this list, and a menu with no rule gets appended to.
+
+    `dx.__skeleton__` already runs invariant checks, then enumerations, then
+    heuristics, so the panel follows it rather than inventing an order —
+    which also makes the dropdown read from "this is broken" down to "this
+    might repay a look".
+    """
+    import re
+    from pathlib import Path
+
+    from skeliner import dx
+    from skeliner.plot import viewer as viewer_mod
+
+    html = Path(viewer_mod.__file__).with_name("viewer.html").read_text()
+    sel = re.search(r'id="dxKindSel".*?</select>', html, re.S | re.I)
+    dropdown = re.findall(r'<option value="([a-z_]+)"', sel.group(0))
+    params = re.findall(
+        r"^\s*(\w+):\s*\[",
+        re.search(r"const DX_PARAMS = \{(.*?)\n            \};", html, re.S).group(1),
+        re.M,
+    )
+    source = Path(viewer_mod.__file__).read_text()
+    registry = re.findall(
+        r'^\s*"([a-z_]+)": \(',
+        re.search(r"DIAGNOSTICS = \{(.*?)\n    \}", source, re.S).group(1),
+        re.M,
+    )
+
+    assert dropdown == params, f"dropdown {dropdown} vs DX_PARAMS {params}"
+    assert dropdown == registry, f"dropdown {dropdown} vs DIAGNOSTICS {registry}"
+
+    # and that shared order is dx's own
+    backing = {
+        "orphans": "check_connectivity",
+        "degree": "nodes_of_degree",
+        "twigs": "twigs_of_length",
+        "tips": "suspicious_tips",
+        "junctions": "suspicious_junctions",
+    }
+    assert set(backing) == set(dropdown), "a diagnostic has no declared dx backing"
+    ranks = [dx.__skeleton__.index(backing[k]) for k in dropdown]
+    assert ranks == sorted(ranks), (
+        f"panel order {dropdown} does not follow dx.__skeleton__ (ranks {ranks})"
+    )
+
+
 def test_a_diagnostic_marks_nodes_without_touching_the_skeleton(bin_client):
     """It reports candidates and never edits — the same split `pre` draws
     between its `find_*` and `remove_*` functions."""
@@ -2507,6 +2554,66 @@ def test_a_marker_lands_exactly_on_the_node_it_marks(tmp_path, monkeypatch):
             assert m["position"] == pytest.approx(expected, abs=1.0), (
                 f"marker for node {nid} is not where that node is drawn"
             )
+
+
+def test_a_proposed_cut_is_drawn_and_not_only_named(tmp_path, monkeypatch):
+    """ "cut 79+84" asks the eye to resolve two node ids into two branches.
+
+    That is the one job the viewer exists to do, so a diagnostic with an
+    opinion about *which cable* has to put it on the geometry.  A proposal
+    living only in a label is not reviewable.
+
+    Driven through `twigs`, the one diagnostic that still has an opinion
+    about which edges belong to a candidate.
+    """
+    from pathlib import Path
+
+    from starlette.testclient import TestClient
+
+    from skeliner import skeletonize
+    from skeliner.io import load_mesh
+    from skeliner.plot import viewer as viewer_mod
+
+    monkeypatch.setattr(viewer_mod, "_STATE_DIR", tmp_path, raising=False)
+    mesh = load_mesh(Path(__file__).parent / "data" / "60427.obj")
+    skel = skeletonize(mesh, verbose=False)
+
+    app = _create_app(preload_mesh=mesh, port=8919)
+    with TestClient(app) as client:
+        path = tmp_path / "skeleton.npz"
+        skel.to_npz(path)
+        client.post("/upload", files={"file": ("skeleton.npz", path.read_bytes())})
+        name = next(iter(client.get("/skeletons").json()))
+
+        r = client.post(
+            "/diagnose",
+            json={
+                "name": name,
+                "kind": "twigs",
+                "params": {"maxRatio": 1000.0, "maxNodes": 10},
+            },
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["n"] > 0, "fixture produced no candidates to draw"
+        assert body["nCut"] > 0, "candidates were found but nothing was drawn"
+
+        ann = client.get("/annotations").json()
+        groups = [g for g in ann.get("edge_groups", []) if g.get("dx") == "twigs"]
+        assert groups, "the diagnostic never reached the geometry"
+
+        drawn = np.asarray(client.get("/skeletons").json()[name]["nodes"]).reshape(
+            -1, 3
+        )
+        lo, hi = drawn.min(axis=0) - 1.0, drawn.max(axis=0) + 1.0
+        for g in groups:
+            assert g["segments"], "an empty group draws nothing"
+            for seg in g["segments"]:
+                for point in seg:
+                    p = np.asarray(point)
+                    assert ((p >= lo) & (p <= hi)).all(), (
+                        "segment drawn outside the skeleton — centroid not applied"
+                    )
 
 
 def test_an_unknown_diagnostic_is_named_rather_than_crashing(bin_client):

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2017,3 +2017,137 @@ def test_preprocess_does_not_announce_a_drop_it_repairs(reassign_client, capsys)
     said = capsys.readouterr().out
     assert "components dropped" not in said, said
     assert state["neurites"] is not None, "preprocess must republish"
+
+
+# ── which track a run takes, and which parameters it reads ────────────
+#
+# `skeletonize` accepts every parameter on either track and forwards only
+# the applicable ones, so a setting made against the track that is not
+# running is ignored in silence.  The viewer picks the track from state the
+# user cannot see, so it has to say which one it picked and which of the
+# parameters that one reads.
+
+TRACK_HEADERS = {
+    "direct": "skeletonize from raw mesh",
+    "preprocessing": "skeletonize from preprocessed mesh components",
+}
+
+
+def _skel_defaults_tracks():
+    """Parse the dialog's per-parameter track tags out of viewer.html."""
+    import re
+    from pathlib import Path
+
+    from skeliner.plot import viewer as viewer_mod
+
+    html = Path(viewer_mod.__file__).with_name("viewer.html").read_text()
+    block = html.split("const SKEL_DEFAULTS = {")[1].split("\n            };")[0]
+
+    tags = {}
+    for m in re.finditer(r"(\w+):\s*\{", block):
+        depth, j = 1, m.end()
+        while depth:
+            depth += {"{": 1, "}": -1}.get(block[j], 0)
+            j += 1
+        body = block[m.end() : j - 1]
+        raw = re.search(r"tracks:\s*(BOTH|\[[^\]]*\])", body)
+        assert raw, f"{m.group(1)} carries no tracks tag"
+        tags[m.group(1)] = (
+            ["direct", "preprocessing"]
+            if raw.group(1) == "BOTH"
+            else re.findall(r'"(\w+)"', raw.group(1))
+        )
+    return tags
+
+
+def test_the_dialog_greys_exactly_what_the_track_ignores():
+    """The tags decide which fields are disabled.  Wrong ones would either
+    grey out a live parameter or leave a dead one editable, and both read as
+    the dialog working."""
+    import inspect
+    import re
+    import sys
+    from pathlib import Path
+
+    src = Path(sys.modules["skeliner.skeletonize"].__file__).read_text()
+    forwarded = src.split("return _skeletonize_preproc(")[1].split("\n        )")[0]
+    prepro = set(re.findall(r"(\w+)=", forwarded))
+    direct = set(
+        inspect.signature(
+            sys.modules["skeliner.skeletonize"]._skeletonize_direct
+        ).parameters
+    )
+
+    tags = _skel_defaults_tracks()
+    assert len(tags) > 10, "parser found almost nothing — it has drifted"
+
+    for key, declared in tags.items():
+        actual = sorted(
+            (["direct"] if key in direct else [])
+            + (["preprocessing"] if key in prepro else [])
+        )
+        assert sorted(declared) == actual, (
+            f"{key}: dialog says {sorted(declared)}, tracks forward {actual}"
+        )
+
+
+@pytest.mark.parametrize("track", ["direct", "preprocessing"])
+def test_the_run_reports_and_logs_the_track_it_took(reassign_client, capsys, track):
+    """Reported by the server rather than inferred by the page, so the label
+    and the branch cannot disagree."""
+    client, state, _ = reassign_client
+    if track == "direct":
+        state["neurites"] = None
+
+    assert client.get("/loaded").json()["track"] == track
+
+    r = client.post("/skeletonize", json={"params": {}})
+    assert r.status_code == 200, r.text
+    assert r.json()["ranTrack"] == track
+    assert TRACK_HEADERS[track] in capsys.readouterr().out
+
+
+def _skel_defaults_values():
+    """Parse the dialog's declared default for each parameter."""
+    import re
+    from pathlib import Path
+
+    from skeliner.plot import viewer as viewer_mod
+
+    html = Path(viewer_mod.__file__).with_name("viewer.html").read_text()
+    block = html.split("const SKEL_DEFAULTS = {")[1].split("\n            };")[0]
+
+    literals = {"true": True, "false": False}
+    out = {}
+    for m in re.finditer(r"(\w+):\s*\{", block):
+        depth, j = 1, m.end()
+        while depth:
+            depth += {"{": 1, "}": -1}.get(block[j], 0)
+            j += 1
+        raw = re.search(r"value:\s*([^,]+),", block[m.end() : j - 1]).group(1).strip()
+        out[m.group(1)] = (
+            literals[raw]
+            if raw in literals
+            else (float(raw) if "." in raw else int(raw))
+        )
+    return out
+
+
+def test_the_dialog_agrees_with_skeletonize_about_the_defaults():
+    """The dialog decides what counts as "unchanged", and `getSkelParams`
+    sends only what differs.  A dialog default drifting from the signature
+    would either send a value the user never chose, or withhold one they
+    did — and the panel would look right either way."""
+    import inspect
+    import sys
+
+    sig = inspect.signature(sys.modules["skeliner.skeletonize"].skeletonize).parameters
+    declared = _skel_defaults_values()
+    assert len(declared) > 10, "parser found almost nothing — it has drifted"
+
+    for key, val in declared.items():
+        assert key in sig, f"{key} is offered by the dialog but is not a parameter"
+        assert sig[key].default == val, (
+            f"{key}: dialog offers {val!r}, skeletonize defaults to "
+            f"{sig[key].default!r}"
+        )

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -322,7 +322,7 @@ def test_organelle_target_writes_the_manual_mask(reassign_client):
 
 # ── /bin ──────────────────────────────────────────────────────────────
 #
-# A node *is* the set of mesh vertices it owns, so Edit Partition renders a
+# A node *is* the set of mesh vertices it owns, so Edit ▸ Skeleton renders a
 # selected node as that surface.  A bin is small enough to fetch per click,
 # which is why the partition is never shipped in bulk.
 
@@ -392,7 +392,7 @@ def test_bins_do_not_overlap(bin_client):
 
 def test_node_0_is_reported_as_not_editable(bin_client):
     """Node 0's "bin" is ``soma.verts``, assigned wholesale by the soma
-    stitch.  It belongs to Edit Mesh, not Edit Partition."""
+    stitch.  It belongs to Edit ▸ Mesh Comp., not Edit ▸ Skeleton."""
     client, name, _, _ = bin_client
     assert (
         client.post("/bin", json={"name": name, "node": 0}).json()["editable"] is False
@@ -2151,3 +2151,72 @@ def test_the_dialog_agrees_with_skeletonize_about_the_defaults():
             f"{key}: dialog offers {val!r}, skeletonize defaults to "
             f"{sig[key].default!r}"
         )
+
+
+# ── the mode selector ─────────────────────────────────────────────────
+#
+# Three modes, named after the three objects in the derivation chain: the
+# mesh, the components broken out of it, the skeleton built from those.
+# Each is wired through three parallel tables — the buttons, the row
+# containers they reveal, and the click handlers — so renaming one means
+# editing all three.  A site missed leaves a button that lights up over an
+# empty panel, which reads as the mode simply having nothing in it.
+
+
+def _mode_wiring():
+    """Parse the mode keys, their element ids and the click wiring."""
+    import re
+    from pathlib import Path
+
+    from skeliner.plot import viewer as viewer_mod
+
+    html = Path(viewer_mod.__file__).with_name("viewer.html").read_text()
+
+    def table(name):
+        block = html.split(f"const {name} = {{")[1].split("};")[0]
+        return dict(re.findall(r'(\w+):\s*"([^"]+)"', block))
+
+    wired = dict(
+        re.findall(
+            r'getElementById\("(\w+)"\)\s*\.addEventListener\('
+            r'"click",\s*\(\)\s*=>\s*setMode\("(\w+)"\)',
+            html,
+        )
+    )
+    default = re.search(r'let panelMode = "(\w+)"', html).group(1)
+    return html, table("MODE_ROWS"), table("MODE_BTNS"), wired, default
+
+
+def test_every_mode_has_a_button_a_panel_and_a_handler():
+    """`setMode` shows one row container and lights one button, both looked
+    up by id.  An id that names nothing throws inside the loop, leaving the
+    panel on whichever mode it was already displaying."""
+    html, rows, btns, wired, default = _mode_wiring()
+
+    assert set(rows) == set(btns), (
+        f"MODE_ROWS has {sorted(rows)}, MODE_BTNS has {sorted(btns)}"
+    )
+    assert len(rows) == 3, f"expected three modes, parsed {sorted(rows)}"
+    assert default in rows, f"panelMode starts at {default!r}, not a mode"
+
+    for mode, row_id in rows.items():
+        assert f'id="{row_id}"' in html, f"{mode}: no element id={row_id!r}"
+    for mode, btn_id in btns.items():
+        assert f'id="{btn_id}"' in html, f"{mode}: no element id={btn_id!r}"
+        assert wired.get(btn_id) == mode, (
+            f"{btn_id} calls setMode({wired.get(btn_id)!r}), expected {mode!r}"
+        )
+
+
+def test_the_mode_buttons_are_exactly_the_ones_styled_as_modes():
+    """The active-mode highlight is CSS on `button.mode-btn[data-active]`.
+    A mode button without the class switches the panel while still looking
+    inactive; anything else carrying it looks like a fourth mode."""
+    import re
+
+    html, _, btns, _, _ = _mode_wiring()
+
+    styled = set(re.findall(r'<button\s+id="(\w+)"\s+class="mode-btn"', html))
+    assert styled == set(btns.values()), (
+        f"styled as modes: {sorted(styled)}, declared: {sorted(btns.values())}"
+    )

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1835,3 +1835,137 @@ def test_a_dropped_neurites_file_shows_the_names_it_carries(named_client, tmp_pa
     ann = client.get("/annotations").json()
     named = {h["neurite"]: h["label"] for h in ann["highlights"] if "neurite" in h}
     assert named[0].startswith("axon (")
+
+
+# ── uploading a drop as one gesture ───────────────────────────────────
+#
+# A drag-drop is one gesture, but the browser hands the files over in the
+# OS's order.  Applied independently, a mesh arriving after its companions
+# clears them as though they had belonged to a previous session — and the
+# sweep unlinks them from the port directory too, so nothing is recoverable.
+
+
+@pytest.fixture
+def drop_files(tmp_path):
+    """A mesh, the components naming its faces, and a skeleton of it."""
+    from skeliner import io as skio
+    from skeliner.dataclass import MeshComponents
+    from skeliner.skeletonize import skeletonize
+
+    mesh, soma, org, neurites = _tube_with_components()
+    comp = MeshComponents(
+        soma=soma, organelles=org, neurites=neurites, discarded=Discarded([])
+    )
+
+    mesh_path = tmp_path / "mesh_cleaned.obj"
+    comp_path = tmp_path / "components.npz"
+    skel_path = tmp_path / "skeleton.npz"
+    mesh.export(mesh_path)
+    skio.save_components_npz(comp, comp_path)
+    skeletonize(mesh, verbose=False).to_npz(skel_path)
+
+    # The order a Finder selection arrives in, and the one that used to lose
+    # the components: "components.npz" sorts ahead of "mesh_cleaned.obj".
+    assert sorted(p.name for p in (mesh_path, comp_path)) == [
+        "components.npz",
+        "mesh_cleaned.obj",
+    ]
+    return mesh_path, comp_path, skel_path
+
+
+@pytest.fixture
+def drop_client(tmp_path, monkeypatch):
+    from starlette.testclient import TestClient
+
+    from skeliner.plot import viewer as viewer_mod
+
+    monkeypatch.setattr(viewer_mod, "_STATE_DIR", tmp_path / "state", raising=False)
+    with TestClient(_create_app(port=8913)) as client:
+        yield client
+
+
+def _as_batch(*paths):
+    return [
+        ("files", (p.name, p.read_bytes(), "application/octet-stream")) for p in paths
+    ]
+
+
+def _neurite_labels(client):
+    ann = client.get("/annotations").json()
+    return [h.get("label", "") for h in ann.get("highlights", []) if "neurite" in h]
+
+
+def test_a_drop_applies_the_mesh_before_the_files_that_index_it(
+    drop_client, drop_files
+):
+    """Ordered by what the files are, not by when they arrived.  Sorting on
+    the client would fix the drag-drop path and leave every other caller
+    with the old behaviour."""
+    mesh_path, comp_path, _ = drop_files
+    r = drop_client.post("/upload_batch", files=_as_batch(comp_path, mesh_path))
+
+    assert r.status_code == 200, r.text
+    assert [x["name"] for x in r.json()["results"]] == [
+        "mesh_cleaned.obj",
+        "components.npz",
+    ]
+
+
+def test_components_survive_a_mesh_that_arrived_after_them(drop_client, drop_files):
+    mesh_path, comp_path, _ = drop_files
+    drop_client.post("/upload_batch", files=_as_batch(comp_path, mesh_path))
+
+    assert drop_client.get("/loaded").json()["mesh"] is not None
+    assert _neurite_labels(drop_client), "the mesh cleared the components it came with"
+
+
+def test_a_drop_still_clears_what_belonged_to_the_previous_mesh(
+    drop_client, drop_files
+):
+    """Batching spares the gesture's own files, not the session before it."""
+    mesh_path, comp_path, _ = drop_files
+    drop_client.post("/upload_batch", files=_as_batch(comp_path, mesh_path))
+    assert _neurite_labels(drop_client)
+
+    drop_client.post("/upload_batch", files=_as_batch(mesh_path))
+    assert not _neurite_labels(drop_client)
+
+
+def test_a_skeleton_in_a_drop_binds_to_the_mesh_it_came_with(drop_client, drop_files):
+    """It is applied after the mesh, so ``_skel_is_stale`` sees the object
+    the drop carried rather than whatever happened to be loaded."""
+    mesh_path, _, skel_path = drop_files
+    drop_client.post("/upload_batch", files=_as_batch(skel_path, mesh_path))
+
+    r = drop_client.post(
+        "/edge_edit_preview", json={"name": "skeleton.npz", "u": 1, "v": 2}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["ok"], r.json()
+
+
+def test_a_drop_naming_two_meshes_is_refused(drop_client, drop_files, tmp_path):
+    """Which mesh the companions belong to is unanswerable, and guessing
+    silently discards one set."""
+    mesh_path, comp_path, _ = drop_files
+    other = tmp_path / "other.obj"
+    trimesh.creation.box(extents=(4, 4, 4)).export(other)
+
+    r = drop_client.post("/upload_batch", files=_as_batch(mesh_path, other, comp_path))
+    assert r.status_code == 400
+    assert "more than one mesh" in r.json()["error"]
+
+
+def test_a_new_mesh_clears_the_components_that_chose_the_track(drop_client, drop_files):
+    """``/skeletonize`` reads ``neurites`` to pick the preprocessing track.
+    Left behind, a components file from the mesh being replaced sends the
+    next run down that track naming faces that no longer exist."""
+    mesh_path, comp_path, _ = drop_files
+    drop_client.post("/upload_batch", files=_as_batch(comp_path, mesh_path))
+    assert _neurite_labels(drop_client)
+
+    drop_client.post(
+        "/upload",
+        files={"file": (mesh_path.name, mesh_path.read_bytes(), "application/octet")},
+    )
+    assert not _neurite_labels(drop_client)

--- a/uv.lock
+++ b/uv.lock
@@ -3451,7 +3451,7 @@ wheels = [
 
 [[package]]
 name = "skeliner"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
~some prerequisites to do before incorporating some ideas from #34 into the post-processing pipeline.~

~the direction is to first make the viewer richer, and fix a few known bugs/annoyances.~

~then we will add more skeleton diagnostics and editing capacities to the viewer in part 2.~

The scope of the viewer prerequisite changes is smaller than I expected so I will just do the whole version in one PR (a mistake, likely, but here we are).

The goal of this PR/release is to expose/add skeleton anomalies detection toolsets on the viewer directly (we can already manipulate the bin assignment and clip and graft edges from v0.3.0). 
